### PR TITLE
Sdx.Web.Url 用ユニットテストの修正

### DIFF
--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -44,7 +44,7 @@ namespace Sdx.Web
       }
     }
 
-    private string BuildQueryString(Dictionary<string,string> param)
+    private string BuildQueryString(List<Dictionary<string,string>> param)
     {
       if (param.Count == 0)
       {
@@ -53,8 +53,8 @@ namespace Sdx.Web
 
       var sb = new StringBuilder();
       sb.Append("?");
-      param.ToList().ForEach(
-        kv => sb.AppendFormat("{0}={1}&", kv.Key, kv.Value)
+      param.ForEach(
+        dic => sb.AppendFormat("{0}={1}&", dic.First().Key, dic.First().Value)
       );
 
       return sb.ToString().TrimEnd('&');
@@ -67,22 +67,20 @@ namespace Sdx.Web
       );
       return path;
     }
-    /*
+
     public string Build()
     {
       string path = this.BuildPath();
-      string query = this.BuildQueryString(this.Param);
+      string query = this.BuildQueryString(this.ParamList);
       return path + query;
     }
 
     public string Build(Dictionary<string, string> add)
     {
+      var tmpList = new List<Dictionary<string, string>>() { add };
       string path = this.BuildPath();
       string query = this.BuildQueryString(
-        this.Param
-          .Where(p => add.ContainsKey(p.Key) == false)
-          .Concat(add)
-          .ToDictionary(p => p.Key, p => p.Value)
+        this.ParamList.Concat(tmpList).ToList()
       );
       return path + query;
     }
@@ -91,9 +89,9 @@ namespace Sdx.Web
     {
       string path = this.BuildPath();
       string query = this.BuildQueryString(
-        this.Param
-          .Where(p => exclude.Contains(p.Key) == false)
-          .ToDictionary(p => p.Key, p => p.Value)
+        this.ParamList
+          .Where(dic => exclude.Contains(dic.First().Key) == false)
+          .ToList()
       );
       return path + query;
     }
@@ -102,13 +100,13 @@ namespace Sdx.Web
     {
       string path = this.BuildPath();
       string query = this.BuildQueryString(
-        this.Param
-          .Where(p => exclude.Contains(p.Key) == false)
-          .ToDictionary(p => p.Key, p => p.Value)
+        this.ParamList
+          .Where(dic => exclude.Contains(dic.First().Key) == false)
+          .ToList()
       );
       return path + query;
     }
-    */
+
     public string Domain
     {
       get; set;

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -12,7 +12,7 @@ namespace Sdx.Web
     {
       //@var System.Uri
       var uri = new Uri(urlStr);
-      this.Param = new Dictionary<string, string>();
+      this.ParamList = new List<Dictionary<string,string>>();
 
       //パス用の情報を保存
       this.Scheme = uri.Scheme;
@@ -23,22 +23,24 @@ namespace Sdx.Web
       if (uri.Query.Contains('?'))
       {
         string query = uri.Query.Trim('?');
+        var QueryStringList = new List<string>();
 
         //パラメータの項目数が複数か単独か
         if(query.Contains('&'))
         {
-          string[] paramArray = query.Split('&');
-          paramArray.ToList().ForEach(str =>
-          {
-            string[] tmp = str.Split('=');
-            this.Param[tmp[0]] = tmp[1];
-          });
+          QueryStringList = query.Split('&').ToList();
         }
         else
         {
-          string[] tmp = query.Split('=');
-          this.Param[tmp[0]] = tmp[1];
+          QueryStringList.Add(query);
         }
+
+        QueryStringList.ToList().ForEach(str =>
+        {
+          string[] tmp = str.Split('=');
+          var param = new Dictionary<string, string>() { { tmp[0], tmp[1] } };
+          this.ParamList.Add(param);
+        });
       }
     }
 
@@ -65,7 +67,7 @@ namespace Sdx.Web
       );
       return path;
     }
-
+    /*
     public string Build()
     {
       string path = this.BuildPath();
@@ -106,7 +108,7 @@ namespace Sdx.Web
       );
       return path + query;
     }
-
+    */
     public string Domain
     {
       get; set;
@@ -117,7 +119,7 @@ namespace Sdx.Web
       get; set;
     }
 
-    private Dictionary<string, string> Param
+    private List<Dictionary<string,string>> ParamList
     {
       get; set;
     }
@@ -129,18 +131,27 @@ namespace Sdx.Web
 
     public void SetParam(string key, string value)
     {
-      this.Param[key] = value;
+      var tmp = new Dictionary<string,string>(){{key, value}};
+      this.ParamList.Add(tmp);
     }
 
     public string GetParam(string key)
     {
-      return this.Param[key];
+      return this.GetParamList(key).Last();
     }
 
-    //まだ使用しないのでとりあえず定義だけ
     public List<string> GetParamList(string key)
     {
-      return new List<string>() { "" };
+      var list = new List<string>();
+      this.ParamList.ForEach(dic =>
+      {
+        if (dic.ContainsKey(key))
+        {
+          list.Add(dic.First().Value);
+        }
+      });
+
+      return list;
     }
   }
 }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -43,7 +43,7 @@ namespace Sdx.Web
       }
     }
 
-    private string BuildQueryString(List<Dictionary<string,string>> param)
+    private string BuildQueryString(List<KeyValuePair<string,string>> param)
     {
       if (param.Count == 0)
       {
@@ -52,11 +52,7 @@ namespace Sdx.Web
 
       var sb = new StringBuilder();
       sb.Append("?");
-      param.ForEach(dic => {
-        if(dic.Count > 0) {
-          sb.AppendFormat("{0}={1}&", dic.First().Key, dic.First().Value);
-        }
-      });
+      param.ForEach(kv => sb.AppendFormat("{0}={1}&", kv.Key, kv.Value));
 
       return sb.ToString().TrimEnd('&');
     }
@@ -78,12 +74,10 @@ namespace Sdx.Web
 
     public string Build(Dictionary<string, string> add)
     {
-      var tmpList = new List<Dictionary<string, string>>() { add };
       string path = this.BuildPath();
       string query = this.BuildQueryString(
         this.ParamList
-          .Where(dic => add.ContainsKey(dic.First().Key) == false)
-          .Concat(tmpList)
+          .Concat(add.ToList())
           .ToList()
       );
       return path + query;
@@ -94,7 +88,7 @@ namespace Sdx.Web
       string path = this.BuildPath();
       string query = this.BuildQueryString(
         this.ParamList
-          .Where(dic => exclude.Contains(dic.First().Key) == false)
+          .Where(kv => exclude.Contains(kv.Key) == false)
           .ToList()
       );
       return path + query;
@@ -105,7 +99,7 @@ namespace Sdx.Web
       string path = this.BuildPath();
       string query = this.BuildQueryString(
         this.ParamList
-          .Where(dic => exclude.Contains(dic.First().Key) == false)
+          .Where(kv => exclude.Contains(kv.Key) == false)
           .ToList()
       );
       return path + query;

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -124,6 +124,11 @@ namespace Sdx.Web
       get; set;
     }
 
+    /// <summary>
+    /// セットされたパラメータを管理するプロパティ
+    /// Tuple<Item1 = パラメータのキー, Item2=パラメータの値> で
+    /// セットされます
+    /// </summary>
     private List<Tuple<string, string>> ParamList
     {
       get; set;

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -12,7 +12,7 @@ namespace Sdx.Web
     {
       //@var System.Uri
       var uri = new Uri(urlStr);
-      this.ParamList = new List<Dictionary<string,string>>();
+      this.ParamList = new List<KeyValuePair<string,string>>();
 
       //パス用の情報を保存
       this.Scheme = uri.Scheme;
@@ -35,11 +35,10 @@ namespace Sdx.Web
           QueryStringList.Add(query);
         }
 
-        QueryStringList.ToList().ForEach(str =>
+        QueryStringList.ForEach(str =>
         {
           string[] tmp = str.Split('=');
-          var param = new Dictionary<string, string>() { { tmp[0], tmp[1] } };
-          this.ParamList.Add(param);
+          this.ParamList.Add(new KeyValuePair<string, string>(tmp[0], tmp[1]));
         });
       }
     }
@@ -122,7 +121,7 @@ namespace Sdx.Web
       get; set;
     }
 
-    private List<Dictionary<string,string>> ParamList
+    private List<KeyValuePair<string, string>> ParamList
     {
       get; set;
     }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -7,17 +7,12 @@ namespace Sdx.Web
 {
   public class Url
   {
-    private Dictionary<string, string> paramData;
-    private String scheme;
-    private String localPath;
-    private String domain;
-
     //コンストラクタ
     public Url(string urlStr)
     {
       //@var System.Uri
       var uri = new Uri(urlStr);
-      this.paramData = new Dictionary<string, string>();
+      this.Param = new Dictionary<string, string>();
 
       //パス用の情報を保存
       this.Scheme = uri.Scheme;
@@ -36,13 +31,13 @@ namespace Sdx.Web
           paramArray.ToList().ForEach(str =>
           {
             string[] tmp = str.Split('=');
-            this.paramData[tmp[0]] = tmp[1];
+            this.Param[tmp[0]] = tmp[1];
           });
         }
         else
         {
           string[] tmp = query.Split('=');
-          this.paramData[tmp[0]] = tmp[1];
+          this.Param[tmp[0]] = tmp[1];
         }
       }
     }
@@ -74,7 +69,7 @@ namespace Sdx.Web
     public string Build()
     {
       string path = this.BuildPath();
-      string query = this.BuildQueryString(this.paramData);
+      string query = this.BuildQueryString(this.Param);
       return path + query;
     }
 
@@ -82,7 +77,7 @@ namespace Sdx.Web
     {
       string path = this.BuildPath();
       string query = this.BuildQueryString(
-        this.paramData
+        this.Param
           .Where(p => add.ContainsKey(p.Key) == false)
           .Concat(add)
           .ToDictionary(p => p.Key, p => p.Value)
@@ -94,7 +89,7 @@ namespace Sdx.Web
     {
       string path = this.BuildPath();
       string query = this.BuildQueryString(
-        this.paramData
+        this.Param
           .Where(p => exclude.Contains(p.Key) == false)
           .ToDictionary(p => p.Key, p => p.Value)
       );
@@ -105,7 +100,7 @@ namespace Sdx.Web
     {
       string path = this.BuildPath();
       string query = this.BuildQueryString(
-        this.paramData
+        this.Param
           .Where(p => exclude.Contains(p.Key) == false)
           .ToDictionary(p => p.Key, p => p.Value)
       );
@@ -114,54 +109,22 @@ namespace Sdx.Web
 
     public string Domain
     {
-      get
-      {
-        return this.domain;
-      }
-
-      set
-      {
-        this.domain = value;
-      }
+      get; set;
     }
 
     public string LocalPath
     {
-      get
-      {
-        return this.localPath;
-      }
-
-      set
-      {
-        this.localPath = value;
-      }
+      get; set;
     }
 
     public Dictionary<string, string> Param
     {
-      get
-      {
-        return this.paramData;
-      }
-
-      set
-      {
-        this.paramData = value;
-      }
+      get; set;
     }
 
     public string Scheme
     {
-      get
-      {
-        return this.scheme;
-      }
-
-      set
-      {
-        this.scheme = value;
-      }
+      get; set;
     }
   }
 }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -117,7 +117,7 @@ namespace Sdx.Web
       get; set;
     }
 
-    public Dictionary<string, string> Param
+    private Dictionary<string, string> Param
     {
       get; set;
     }
@@ -125,6 +125,22 @@ namespace Sdx.Web
     public string Scheme
     {
       get; set;
+    }
+
+    public void SetParam(string key, string value)
+    {
+      this.Param[key] = value;
+    }
+
+    public string GetParam(string key)
+    {
+      return this.Param[key];
+    }
+
+    //まだ使用しないのでとりあえず定義だけ
+    public List<string> GetParamList(string key)
+    {
+      return new List<string>() { "" };
     }
   }
 }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -149,6 +149,12 @@ namespace Sdx.Web
         }
       });
 
+      //存在しないキーを指定された場合以外は、必ず何かしら list に入っているので
+      //この段階で例外を投げる
+      if (list.Count == 0)
+      {
+        throw new KeyNotFoundException();
+      }
       return list;
     }
   }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -80,7 +80,10 @@ namespace Sdx.Web
       var tmpList = new List<Dictionary<string, string>>() { add };
       string path = this.BuildPath();
       string query = this.BuildQueryString(
-        this.ParamList.Concat(tmpList).ToList()
+        this.ParamList
+          .Where(dic => add.ContainsKey(dic.First().Key) == false)
+          .Concat(tmpList)
+          .ToList()
       );
       return path + query;
     }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -13,6 +13,7 @@ namespace Sdx.Web
       //@var System.Uri
       var uri = new Uri(urlStr);
       this.ParamList = new List<KeyValuePair<string,string>>();
+      this.RoopCount = new Dictionary<string, int>();
 
       //パス用の情報を保存
       this.Scheme = uri.Scheme;
@@ -39,6 +40,7 @@ namespace Sdx.Web
         {
           string[] tmp = str.Split('=');
           this.ParamList.Add(new KeyValuePair<string, string>(tmp[0], tmp[1]));
+          this.AddRoopCount(tmp[0]);
         });
       }
     }
@@ -134,11 +136,13 @@ namespace Sdx.Web
     public void AddParam(string key, string value)
     {
       this.ParamList.Add(new KeyValuePair<string,string>(key, value));
+      this.AddRoopCount(key);
     }
 
     public void RemoveParam(string key)
     {
       this.ParamList.RemoveAll(kv => kv.Key == key);
+      this.RoopCount[key] = 0;
     }
 
     /// <summary>
@@ -152,13 +156,17 @@ namespace Sdx.Web
     public List<string> GetParams(string key)
     {
       var list = new List<string>();
-      this.ParamList.ForEach(kv =>
+      foreach(var kv in this.ParamList)
       {
         if (kv.Key == key)
         {
           list.Add(kv.Value);
+          if (list.Count == this.RoopCount[key])
+          {
+            break;
+          }
         }
-      });
+      }
 
       //存在しないキーを指定された場合以外は、必ず何かしら list に入っているので
       //この段階で例外を投げる
@@ -167,6 +175,28 @@ namespace Sdx.Web
         throw new KeyNotFoundException();
       }
       return list;
+    }
+
+    /// <summary>
+    /// ParamList の各キー毎のループ回数を管理するプロパティ
+    /// 同じ名前のキーがセットされたらカウントをアップし、
+    /// 削除されたらカウントを0に戻す
+    /// </summary>
+    private Dictionary<string, int> RoopCount
+    {
+      get; set;
+    }
+
+    private void AddRoopCount(string key)
+    {
+      if (this.RoopCount.ContainsKey(key))
+      {
+        this.RoopCount[key]++;
+      }
+      else
+      {
+        this.RoopCount[key] = 1;
+      }
     }
   }
 }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -76,6 +76,11 @@ namespace Sdx.Web
 
     public string Build(Dictionary<string, string> add)
     {
+      if(add.Count == 0)
+      {
+        return this.Build();
+      }
+
       var tpList = new List<Tuple<string, string>>();
       tpList.Add(Tuple.Create(add.First().Key, add.First().Value));
       string path = this.BuildPath();

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -53,9 +53,11 @@ namespace Sdx.Web
 
       var sb = new StringBuilder();
       sb.Append("?");
-      param.ForEach(
-        dic => sb.AppendFormat("{0}={1}&", dic.First().Key, dic.First().Value)
-      );
+      param.ForEach(dic => {
+        if(dic.Count > 0) {
+          sb.AppendFormat("{0}={1}&", dic.First().Key, dic.First().Value);
+        }
+      });
 
       return sb.ToString().TrimEnd('&');
     }

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -142,6 +142,9 @@ namespace Sdx.Web
       this.ParamList.Add(new KeyValuePair<string,string>(key, value));
     }
 
+    /// <summary>
+    /// 指定された key で検索し "最初に一致した" 要素の値を返す
+    /// </summary>
     public string GetParam(string key)
     {
       return this.GetParams(key).First();

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -12,7 +12,7 @@ namespace Sdx.Web
     {
       //@var System.Uri
       var uri = new Uri(urlStr);
-      this.ParamList = new List<KeyValuePair<string,string>>();
+      this.ParamList = new List<Tuple<string,string>>();
       this.RoopCount = new Dictionary<string, int>();
 
       //パス用の情報を保存
@@ -39,13 +39,13 @@ namespace Sdx.Web
         QueryStringList.ForEach(str =>
         {
           string[] tmp = str.Split('=');
-          this.ParamList.Add(new KeyValuePair<string, string>(tmp[0], tmp[1]));
+          this.ParamList.Add(Tuple.Create(tmp[0], tmp[1]));
           this.AddRoopCount(tmp[0]);
         });
       }
     }
 
-    private string BuildQueryString(List<KeyValuePair<string,string>> param)
+    private string BuildQueryString(List<Tuple<string,string>> param)
     {
       if (param.Count == 0)
       {
@@ -54,7 +54,7 @@ namespace Sdx.Web
 
       var sb = new StringBuilder();
       sb.Append("?");
-      param.ForEach(kv => sb.AppendFormat("{0}={1}&", kv.Key, kv.Value));
+      param.ForEach(tp => sb.AppendFormat("{0}={1}&", tp.Item1, tp.Item2));
 
       return sb.ToString().TrimEnd('&');
     }
@@ -76,10 +76,12 @@ namespace Sdx.Web
 
     public string Build(Dictionary<string, string> add)
     {
+      var tpList = new List<Tuple<string, string>>();
+      tpList.Add(Tuple.Create(add.First().Key, add.First().Value));
       string path = this.BuildPath();
       string query = this.BuildQueryString(
         this.ParamList
-          .Concat(add.ToList())
+          .Concat(tpList)
           .ToList()
       );
       return path + query;
@@ -90,7 +92,7 @@ namespace Sdx.Web
       string path = this.BuildPath();
       string query = this.BuildQueryString(
         this.ParamList
-          .Where(kv => exclude.Contains(kv.Key) == false)
+          .Where(tp => exclude.Contains(tp.Item1) == false)
           .ToList()
       );
       return path + query;
@@ -101,7 +103,7 @@ namespace Sdx.Web
       string path = this.BuildPath();
       string query = this.BuildQueryString(
         this.ParamList
-          .Where(kv => exclude.Contains(kv.Key) == false)
+          .Where(tp => exclude.Contains(tp.Item1) == false)
           .ToList()
       );
       return path + query;
@@ -117,7 +119,7 @@ namespace Sdx.Web
       get; set;
     }
 
-    private List<KeyValuePair<string, string>> ParamList
+    private List<Tuple<string, string>> ParamList
     {
       get; set;
     }
@@ -135,13 +137,13 @@ namespace Sdx.Web
 
     public void AddParam(string key, string value)
     {
-      this.ParamList.Add(new KeyValuePair<string,string>(key, value));
+      this.ParamList.Add(Tuple.Create(key, value));
       this.AddRoopCount(key);
     }
 
     public void RemoveParam(string key)
     {
-      this.ParamList.RemoveAll(kv => kv.Key == key);
+      this.ParamList.RemoveAll(tp => tp.Item1 == key);
       this.RoopCount[key] = 0;
     }
 
@@ -156,11 +158,11 @@ namespace Sdx.Web
     public List<string> GetParams(string key)
     {
       var list = new List<string>();
-      foreach(var kv in this.ParamList)
+      foreach(var tp in this.ParamList)
       {
-        if (kv.Key == key)
+        if (tp.Item1 == key)
         {
-          list.Add(kv.Value);
+          list.Add(tp.Item2);
           if (list.Count == this.RoopCount[key])
           {
             break;

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -145,7 +145,7 @@ namespace Sdx.Web
       {
         if (dic.ContainsKey(key))
         {
-          list.Add(dic.First().Value);
+          list.Add(dic[key]);
         }
       });
 

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -147,7 +147,7 @@ namespace Sdx.Web
       return this.GetParamList(key).Last();
     }
 
-    public List<string> GetParamList(string key)
+    public List<string> GetParams(string key)
     {
       var list = new List<string>();
       this.ParamList.ForEach(dic =>

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -133,8 +133,13 @@ namespace Sdx.Web
 
     public void SetParam(string key, string value)
     {
-      var tmp = new Dictionary<string,string>(){{key, value}};
-      this.ParamList.Add(tmp);
+      this.ParamList.RemoveAll(kv => kv.Key == key);
+      this.AddParam(key, value);
+    }
+
+    public void AddParam(string key, string value)
+    {
+      this.ParamList.Add(new KeyValuePair<string,string>(key, value));
     }
 
     public string GetParam(string key)

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -144,17 +144,17 @@ namespace Sdx.Web
 
     public string GetParam(string key)
     {
-      return this.GetParamList(key).Last();
+      return this.GetParams(key).First();
     }
 
     public List<string> GetParams(string key)
     {
       var list = new List<string>();
-      this.ParamList.ForEach(dic =>
+      this.ParamList.ForEach(kv =>
       {
-        if (dic.ContainsKey(key))
+        if (kv.Key == key)
         {
-          list.Add(dic[key]);
+          list.Add(kv.Value);
         }
       });
 

--- a/Sdx.Web/Url.cs
+++ b/Sdx.Web/Url.cs
@@ -127,13 +127,18 @@ namespace Sdx.Web
 
     public void SetParam(string key, string value)
     {
-      this.ParamList.RemoveAll(kv => kv.Key == key);
+      this.RemoveParam(key);
       this.AddParam(key, value);
     }
 
     public void AddParam(string key, string value)
     {
       this.ParamList.Add(new KeyValuePair<string,string>(key, value));
+    }
+
+    public void RemoveParam(string key)
+    {
+      this.ParamList.RemoveAll(kv => kv.Key == key);
     }
 
     /// <summary>

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -205,7 +205,7 @@ namespace UnitTest
       Assert.Equal("/path/to/api", url.LocalPath);
 
       //List<string> でパラメータ取得
-      var list = url.GetParamList("sameKey");
+      var list = url.GetParams("sameKey");
       Assert.Equal("value0", list[0]);
       Assert.Equal("value1", list[1]);
       Assert.Equal("value2", list[2]);
@@ -247,7 +247,7 @@ namespace UnitTest
 
       //存在しないキーで値を取得しようとした場合、例外になる。
       Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
-      Assert.Throws<KeyNotFoundException>(() => url.GetParamList("unknown"));
+      Assert.Throws<KeyNotFoundException>(() => url.GetParams("unknown"));
 
       //Setメソッドで同じキーのパラメータを追加。上書きはされず値が増えるだけ。取得は新しく追加したほうが優先される。
       url.SetParam("newKey", "newValue2");
@@ -275,12 +275,12 @@ namespace UnitTest
       Assert.Equal("bar", url.GetParam("foo"));
 
       //ParamList
-      var keyList = url.GetParamList("key");
+      var keyList = url.GetParams("key");
       Assert.Equal("", keyList[0]);
       Assert.Equal("", keyList[1]);
       Assert.Equal("", keyList[2]);
 
-      var fooList = url.GetParamList("foo");
+      var fooList = url.GetParams("foo");
       Assert.Equal("", fooList[0]);
       Assert.Equal("", fooList[1]);
       Assert.Equal("bar", fooList[2]);

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -194,5 +194,17 @@ namespace UnitTest
       //存在しないキーを指定して、想定した例外になっているかを確認する
       Assert.Throws<KeyNotFoundException>(() => url.Param["unknown"]);
     }
+
+    [Fact]
+    public void TestArrayParams()
+    {
+      var url = new Sdx.Web.Url("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2");
+    }
+
+    [Fact]
+    public void TestHashParams()
+    {
+      var url = new Sdx.Web.Url("http://example.com/path/to/api?list[key0]=value0&list[key1]=value1&list[key2]=value2");
+    }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -27,18 +27,17 @@ namespace UnitTest
       //コンストラクタの解析が意図通りに行われているか、各部品ごとに確認
       Assert.Equal("example.com", url.Domain);
       Assert.Equal("http", url.Scheme);
-      Assert.Equal("bar", url.Param["foo"]);
-      Assert.Equal("huga", url.Param["hoge"]);
+      Assert.Equal("bar", url.GetParam("foo"));
+      Assert.Equal("huga", url.GetParam("hoge"));
       Assert.Equal("/path/to/api", url.LocalPath);
 
       //新しくパラメータを追加した場合、正しくクエリが生成されているか
-      url.Param["key"] = "value";
+      url.SetParam("key", "value");
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build());
 
       //Setterではなくコンストラクタの引数にパラメータを渡した場合の挙動
       //オブジェクトが持つデータ自体は変わらないようにする
-      var param = new Dictionary<string, string>();
-      param["new"] = "newValue";
+      var param = new Dictionary<string, string>() { {"new", "newValue"} };
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value&new=newValue", url.Build(param));
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build());
 
@@ -80,7 +79,7 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build(unknownArray));
 
       //存在しないキーを指定して、想定した例外になっているかを確認する
-      Assert.Throws<KeyNotFoundException>(() => url.Param["unknown"]);
+      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
 
     [Fact]
@@ -96,8 +95,8 @@ namespace UnitTest
       Assert.Equal("/path/to/api", url.LocalPath);
 
       //パラメータの追加(プロパティ経由)
-      url.Param["key"] = "value";
-      Assert.Equal("value", url.Param["key"]);
+      url.SetParam("key", "value");
+      Assert.Equal("value", url.GetParam("key"));
       Assert.Equal("http://example.com/path/to/api?key=value", url.Build());
 
       //パラメータの追加(引数で)
@@ -136,7 +135,7 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?key=value", url.Build(unknownArray));
 
       //存在しないキーを指定して、想定した例外になっているかを確認する
-      Assert.Throws<KeyNotFoundException>(() => url.Param["unknown"]);
+      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
 
     [Fact]
@@ -152,8 +151,8 @@ namespace UnitTest
       Assert.Equal("/path/to/api", url.LocalPath);
 
       //パラメータの追加(プロパティ経由)
-      url.Param["key"] = "value";
-      Assert.Equal("value", url.Param["key"]);
+      url.SetParam("key", "value");
+      Assert.Equal("value", url.GetParam("key"));
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build());
 
       //パラメータの追加(引数で)
@@ -192,7 +191,7 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build(unknownArray));
 
       //存在しないキーを指定して、想定した例外になっているかを確認する
-      Assert.Throws<KeyNotFoundException>(() => url.Param["unknown"]);
+      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
 
     [Fact]

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -17,6 +17,7 @@ namespace UnitTest
   [TestClass]
   public class UrlTest : BaseTest
   {
+/*
     [Fact]
     public void TestMultipleParams()
     {
@@ -193,7 +194,7 @@ namespace UnitTest
       //存在しないキーを指定して、想定した例外になっているかを確認する
       Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
-
+*/
     [Fact]
     public void TestSameKeyNameParams()
     {
@@ -212,36 +213,36 @@ namespace UnitTest
 
       //取得したListに値は追加してもBuild時に生成されるURL文字列に影響ないことを期待
       list.Add("addedValue");
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
 
       //文字列でパラメータ取得。Listの最終要素が取得できることを期待
       var str = url.GetParam("sameKey");
       Assert.Equal("value2", str);
-      str = "addedStr";
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
+      //str = "addedStr";
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
 
       //Setメソッドでパラメータ追加
       url.SetParam("newKey", "newValue");
       Assert.Equal("newValue", url.GetParam("newKey"));
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //Build()の引数でパラメータ追加
-      var tmpParam = new Dictionary<string, string>() { {"tmpKey", "tmpValue"} };
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&tmpKey=tmpValue", url.Build(tmpParam));
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      //var tmpParam = new Dictionary<string, string>() { {"tmpKey", "tmpValue"} };
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&tmpKey=tmpValue", url.Build(tmpParam));
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //Build()の引数でパラメータ削除テスト
-      var exclude = new List<string>() { "sameKey" };
-      Assert.Equal("http://example.com/path/to/api?newKey=newValue", url.Build(exclude));
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      //var exclude = new List<string>() { "sameKey" };
+      //Assert.Equal("http://example.com/path/to/api?newKey=newValue", url.Build(exclude));
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //値が空文字の Dictionary を追加
-      var empValDic = new Dictionary<string, string>() { { "empKey", "" } };
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&empKey=", url.Build(empValDic));
-      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      //var empValDic = new Dictionary<string, string>() { { "empKey", "" } };
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&empKey=", url.Build(empValDic));
+      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //存在しないキーで値を取得しようとした場合、例外になる。
-      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
+      //Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -57,6 +57,19 @@ namespace UnitTest
       var list = new List<string>() { "key" };
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga", url.Build(list));
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build());
+
+      //空の Dictionary を追加
+      var empDic = new Dictionary<string, string>();
+      Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build(empDic));
+
+      //値が空になっている Dictionary を追加
+      // * 値が空文字の場合
+      var empValDic = new Dictionary<string, string>() { { "newkey", "" } };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value&newkey=", url.Build(empValDic));
+
+      // * 値が null の場合
+      var nulValDic = new Dictionary<string, string>() { { "newkey", null } };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value&newkey=", url.Build(nulValDic));
     }
 
     [Fact]
@@ -89,6 +102,19 @@ namespace UnitTest
       var list = new List<string>() { "key" };
       Assert.Equal("http://example.com/path/to/api", url.Build(list));
       Assert.Equal("http://example.com/path/to/api?key=value", url.Build());
+
+      //空の Dictionary を追加
+      var empDic = new Dictionary<string, string>();
+      Assert.Equal("http://example.com/path/to/api?key=value", url.Build(empDic));
+
+      //値が空になっている Dictionary を追加
+      // * 値が空文字の場合
+      var empValDic = new Dictionary<string, string>() { { "newkey", "" } };
+      Assert.Equal("http://example.com/path/to/api?key=value&newkey=", url.Build(empValDic));
+
+      // * 値が null の場合
+      var nulValDic = new Dictionary<string, string>() { { "newkey", null } };
+      Assert.Equal("http://example.com/path/to/api?key=value&newkey=", url.Build(nulValDic));
     }
 
     [Fact]
@@ -121,6 +147,19 @@ namespace UnitTest
       var list = new List<string>() { "key" };
       Assert.Equal("http://example.com/path/to/api?foo=bar", url.Build(list));
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build());
+
+      //空の Dictionary を追加
+      var empDic = new Dictionary<string, string>();
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build(empDic));
+
+      //値が空になっている Dictionary を追加
+      // * 値が空文字の場合
+      var empValDic = new Dictionary<string, string>() { { "newkey", "" } };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value&newkey=", url.Build(empValDic));
+
+      // * 値が null の場合
+      var nulValDic = new Dictionary<string, string>() { { "newkey", null } };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value&newkey=", url.Build(nulValDic));
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -223,31 +223,5 @@ namespace UnitTest
       //存在しないキーで値を取得しようとした場合、例外になる。
       Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
-
-    [Fact]
-    public void TestHashParams()
-    {
-      var url = new Sdx.Web.Url("http://example.com/path/to/api?list[key0]=value0&list[key1]=value1&list[key2]=value2");
-
-      //パスの各部品を取得
-      Assert.Equal("example.com", url.Domain);
-      Assert.Equal("http", url.Scheme);
-      Assert.Equal("/path/to/api", url.LocalPath);
-
-      //List で取得。※list[key0] と list[key1] は全く別のキーとして扱われます
-      var list = url.GetParamList("list[key0]");
-      list.Add("addedValue");
-      Assert.Equal("http://example.com/path/to/api?list[key0]=value0&list[key1]=value1&list[key2]=value2", url.Build());
-
-      //文字列でパラメータ取得。List内に複数の要素がある場合は最後の要素が取得できることを期待
-      url.SetParam("array[key0]", "newValue");
-      var str = url.GetParam("array[key0]");
-      Assert.Equal("newValue", str);
-      str = "addedStr";
-      Assert.Equal("http://example.com/path/to/api?list[key0]=value0&list[key1]=value1&list[key2]=value2&list[key0]=newValue", url.Build());
-
-      //存在しないキーで値を取得しようとした場合、例外になる。
-      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
-    }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -70,6 +70,14 @@ namespace UnitTest
       // * 値が null の場合
       var nulValDic = new Dictionary<string, string>() { { "newkey", null } };
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value&newkey=", url.Build(nulValDic));
+
+      //存在しないキーをList, Array で渡す
+      //(パラメータがまだ何も無い状態で、特定のキーを削除しようとした場合の挙動チェックも兼ねて)
+      var unknownList = new List<string>() { "unknown" };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build(unknownList));
+
+      var unknownArray = new string[] { "unknown" };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build(unknownArray));
     }
 
     [Fact]
@@ -115,6 +123,14 @@ namespace UnitTest
       // * 値が null の場合
       var nulValDic = new Dictionary<string, string>() { { "newkey", null } };
       Assert.Equal("http://example.com/path/to/api?key=value&newkey=", url.Build(nulValDic));
+
+      //存在しないキーをList, Array で渡す
+      //(パラメータがまだ何も無い状態で、特定のキーを削除しようとした場合の挙動チェックも兼ねて)
+      var unknownList = new List<string>() { "unknown" };
+      Assert.Equal("http://example.com/path/to/api?key=value", url.Build(unknownList));
+
+      var unknownArray = new string[] { "unknown" };
+      Assert.Equal("http://example.com/path/to/api?key=value", url.Build(unknownArray));
     }
 
     [Fact]
@@ -160,6 +176,14 @@ namespace UnitTest
       // * 値が null の場合
       var nulValDic = new Dictionary<string, string>() { { "newkey", null } };
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value&newkey=", url.Build(nulValDic));
+
+      //存在しないキーをList, Array で渡す
+      //(パラメータがまだ何も無い状態で、特定のキーを削除しようとした場合の挙動チェックも兼ねて)
+      var unknownList = new List<string>() { "unknown" };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build(unknownList));
+
+      var unknownArray = new string[] { "unknown" };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build(unknownArray));
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -198,6 +198,30 @@ namespace UnitTest
     public void TestArrayParams()
     {
       var url = new Sdx.Web.Url("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2");
+
+      //パスの各部品を取得
+      Assert.Equal("example.com", url.Domain);
+      Assert.Equal("http", url.Scheme);
+      Assert.Equal("/path/to/api", url.LocalPath);
+
+      //List<string> でパラメータ取得
+      var list = url.GetParamList("array[]");
+      Assert.Equal("value0", list[0]);
+      Assert.Equal("value1", list[1]);
+      Assert.Equal("value1", list[2]);
+
+      //取得したListに値は追加してもBuild時に生成されるURL文字列に影響ないことを期待
+      list.Add("addedValue");
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2", url.Build());
+
+      //文字列でパラメータ取得。Listの最終要素が取得できることを期待
+      var str = url.GetParam("array[]");
+      Assert.Equal("value2", str);
+      str = "addedStr";
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2", url.Build());
+
+      //存在しないキーで値を取得しようとした場合、例外になる。
+      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
 
     [Fact]

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -228,6 +228,26 @@ namespace UnitTest
     public void TestHashParams()
     {
       var url = new Sdx.Web.Url("http://example.com/path/to/api?list[key0]=value0&list[key1]=value1&list[key2]=value2");
+
+      //パスの各部品を取得
+      Assert.Equal("example.com", url.Domain);
+      Assert.Equal("http", url.Scheme);
+      Assert.Equal("/path/to/api", url.LocalPath);
+
+      //List で取得。※list[key0] と list[key1] は全く別のキーとして扱われます
+      var list = url.GetParamList("list[key0]");
+      list.Add("addedValue");
+      Assert.Equal("http://example.com/path/to/api?list[key0]=value0&list[key1]=value1&list[key2]=value2", url.Build());
+
+      //文字列でパラメータ取得。List内に複数の要素がある場合は最後の要素が取得できることを期待
+      url.SetParam("array[key0]", "newValue");
+      var str = url.GetParam("array[key0]");
+      Assert.Equal("newValue", str);
+      str = "addedStr";
+      Assert.Equal("http://example.com/path/to/api?list[key0]=value0&list[key1]=value1&list[key2]=value2&list[key0]=newValue", url.Build());
+
+      //存在しないキーで値を取得しようとした場合、例外になる。
+      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -78,6 +78,9 @@ namespace UnitTest
 
       var unknownArray = new string[] { "unknown" };
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build(unknownArray));
+
+      //存在しない値を取得する
+      Assert.Equal(null, url.Param["unknown"]);
     }
 
     [Fact]
@@ -131,6 +134,9 @@ namespace UnitTest
 
       var unknownArray = new string[] { "unknown" };
       Assert.Equal("http://example.com/path/to/api?key=value", url.Build(unknownArray));
+
+      //存在しない値を取得する
+      Assert.Equal(null, url.Param["unknown"]);
     }
 
     [Fact]
@@ -184,6 +190,9 @@ namespace UnitTest
 
       var unknownArray = new string[] { "unknown" };
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build(unknownArray));
+
+      //存在しない値を取得する
+      Assert.Equal(null, url.Param["unknown"]);
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -195,9 +195,9 @@ namespace UnitTest
     }
 
     [Fact]
-    public void TestArrayParams()
+    public void TestSameKeyNameParams()
     {
-      var url = new Sdx.Web.Url("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2");
+      var url = new Sdx.Web.Url("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2");
 
       //パスの各部品を取得
       Assert.Equal("example.com", url.Domain);
@@ -205,40 +205,40 @@ namespace UnitTest
       Assert.Equal("/path/to/api", url.LocalPath);
 
       //List<string> でパラメータ取得
-      var list = url.GetParamList("array[]");
+      var list = url.GetParamList("sameKey");
       Assert.Equal("value0", list[0]);
       Assert.Equal("value1", list[1]);
-      Assert.Equal("value1", list[2]);
+      Assert.Equal("value2", list[2]);
 
       //取得したListに値は追加してもBuild時に生成されるURL文字列に影響ないことを期待
       list.Add("addedValue");
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
 
       //文字列でパラメータ取得。Listの最終要素が取得できることを期待
-      var str = url.GetParam("array[]");
+      var str = url.GetParam("sameKey");
       Assert.Equal("value2", str);
       str = "addedStr";
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
 
       //Setメソッドでパラメータ追加
       url.SetParam("newKey", "newValue");
       Assert.Equal("newValue", url.GetParam("newKey"));
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //Build()の引数でパラメータ追加
       var tmpParam = new Dictionary<string, string>() { {"tmpKey", "tmpValue"} };
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue&tmpKey=tmpValue", url.Build(tmpParam));
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&tmpKey=tmpValue", url.Build(tmpParam));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //Build()の引数でパラメータ削除テスト
-      var exclude = new List<string>() { "array[]" };
+      var exclude = new List<string>() { "sameKey" };
       Assert.Equal("http://example.com/path/to/api?newKey=newValue", url.Build(exclude));
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //値が空文字の Dictionary を追加
       var empValDic = new Dictionary<string, string>() { { "empKey", "" } };
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue&empKey=", url.Build(empValDic));
-      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&empKey=", url.Build(empValDic));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //存在しないキーで値を取得しようとした場合、例外になる。
       Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -213,33 +213,38 @@ namespace UnitTest
 
       //取得したListに値は追加してもBuild時に生成されるURL文字列に影響ないことを期待
       list.Add("addedValue");
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
 
       //文字列でパラメータ取得。Listの最終要素が取得できることを期待
       var str = url.GetParam("sameKey");
       Assert.Equal("value2", str);
-      //str = "addedStr";
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
+      str = "addedStr";
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2", url.Build());
 
       //Setメソッドでパラメータ追加
       url.SetParam("newKey", "newValue");
       Assert.Equal("newValue", url.GetParam("newKey"));
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //Build()の引数でパラメータ追加
-      //var tmpParam = new Dictionary<string, string>() { {"tmpKey", "tmpValue"} };
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&tmpKey=tmpValue", url.Build(tmpParam));
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      var tmpParam = new Dictionary<string, string>() { {"tmpKey", "tmpValue"} };
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&tmpKey=tmpValue", url.Build(tmpParam));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
-      //Build()の引数でパラメータ削除テスト
-      //var exclude = new List<string>() { "sameKey" };
-      //Assert.Equal("http://example.com/path/to/api?newKey=newValue", url.Build(exclude));
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      //Build()の引数でパラメータ削除テスト(List)
+      var excludeList = new List<string>() { "sameKey" };
+      Assert.Equal("http://example.com/path/to/api?newKey=newValue", url.Build(excludeList));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+
+      //Build()の引数でパラメータ削除テスト(Array)
+      var excludeArray = new string[] { "sameKey" };
+      Assert.Equal("http://example.com/path/to/api?newKey=newValue", url.Build(excludeArray));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //値が空文字の Dictionary を追加
-      //var empValDic = new Dictionary<string, string>() { { "empKey", "" } };
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&empKey=", url.Build(empValDic));
-      //Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
+      var empValDic = new Dictionary<string, string>() { { "empKey", "" } };
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&empKey=", url.Build(empValDic));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //存在しないキーで値を取得しようとした場合、例外になる。
       //Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -17,7 +17,6 @@ namespace UnitTest
   [TestClass]
   public class UrlTest : BaseTest
   {
-/*
     [Fact]
     public void TestMultipleParams()
     {
@@ -194,7 +193,7 @@ namespace UnitTest
       //存在しないキーを指定して、想定した例外になっているかを確認する
       Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
     }
-*/
+
     [Fact]
     public void TestSameKeyNameParams()
     {

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -248,6 +248,16 @@ namespace UnitTest
       //存在しないキーで値を取得しようとした場合、例外になる。
       Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
       Assert.Throws<KeyNotFoundException>(() => url.GetParamList("unknown"));
+
+      //Setメソッドで同じキーのパラメータを追加。上書きはされず値が増えるだけ。取得は新しく追加したほうが優先される。
+      url.SetParam("newKey", "newValue2");
+      Assert.Equal("newValue2", url.GetParam("newKey"));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&newKey=newValue2", url.Build());
+
+      //Build()の引数で同じキーのパラメータ追加。戻り値だけは上書きされる。
+      var addParam = new Dictionary<string, string>() { { "newKey", "newValue3" } };
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue3", url.Build(addParam));
+      Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&newKey=newValue2", url.Build());
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -247,7 +247,8 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue", url.Build());
 
       //存在しないキーで値を取得しようとした場合、例外になる。
-      //Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
+      Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));
+      Assert.Throws<KeyNotFoundException>(() => url.GetParamList("unknown"));
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -94,7 +94,7 @@ namespace UnitTest
       Assert.Equal("http", url.Scheme);
       Assert.Equal("/path/to/api", url.LocalPath);
 
-      //パラメータの追加(プロパティ経由)
+      //パラメータの追加(メソッドで)
       url.SetParam("key", "value");
       Assert.Equal("value", url.GetParam("key"));
       Assert.Equal("http://example.com/path/to/api?key=value", url.Build());
@@ -150,7 +150,7 @@ namespace UnitTest
       Assert.Equal("http", url.Scheme);
       Assert.Equal("/path/to/api", url.LocalPath);
 
-      //パラメータの追加(プロパティ経由)
+      //パラメータの追加(メソッドで)
       url.SetParam("key", "value");
       Assert.Equal("value", url.GetParam("key"));
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build());
@@ -219,6 +219,26 @@ namespace UnitTest
       Assert.Equal("value2", str);
       str = "addedStr";
       Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2", url.Build());
+
+      //Setメソッドでパラメータ追加
+      url.SetParam("newKey", "newValue");
+      Assert.Equal("newValue", url.GetParam("newKey"));
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
+
+      //Build()の引数でパラメータ追加
+      var tmpParam = new Dictionary<string, string>() { {"tmpKey", "tmpValue"} };
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue&tmpKey=tmpValue", url.Build(tmpParam));
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
+
+      //Build()の引数でパラメータ削除テスト
+      var exclude = new List<string>() { "array[]" };
+      Assert.Equal("http://example.com/path/to/api?newKey=newValue", url.Build(exclude));
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
+
+      //値が空文字の Dictionary を追加
+      var empValDic = new Dictionary<string, string>() { { "empKey", "" } };
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue&empKey=", url.Build(empValDic));
+      Assert.Equal("http://example.com/path/to/api?array[]=value0&array[]=value1&array[]=value2&newKey=newValue", url.Build());
 
       //存在しないキーで値を取得しようとした場合、例外になる。
       Assert.Throws<KeyNotFoundException>(() => url.GetParam("unknown"));

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -18,7 +18,7 @@ namespace UnitTest
   public class UrlTest : BaseTest
   {
     [Fact]
-    public void TestMethod1()
+    public void TestMultipleParams()
     {
       Console.WriteLine("TestMethod1");
       //コンストラクタで、URLの分解・解析は済ませておく

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -79,8 +79,8 @@ namespace UnitTest
       var unknownArray = new string[] { "unknown" };
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build(unknownArray));
 
-      //存在しない値を取得する
-      //Assert.Equal(null, url.Param["unknown"]);
+      //存在しないキーを指定して、想定した例外になっているかを確認する
+      Assert.Throws<KeyNotFoundException>(() => url.Param["unknown"]);
     }
 
     [Fact]
@@ -135,8 +135,8 @@ namespace UnitTest
       var unknownArray = new string[] { "unknown" };
       Assert.Equal("http://example.com/path/to/api?key=value", url.Build(unknownArray));
 
-      //存在しない値を取得する
-      //Assert.Equal(null, url.Param["unknown"]);
+      //存在しないキーを指定して、想定した例外になっているかを確認する
+      Assert.Throws<KeyNotFoundException>(() => url.Param["unknown"]);
     }
 
     [Fact]
@@ -191,8 +191,8 @@ namespace UnitTest
       var unknownArray = new string[] { "unknown" };
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build(unknownArray));
 
-      //存在しない値を取得する
-      //Assert.Equal(null, url.Param["unknown"]);
+      //存在しないキーを指定して、想定した例外になっているかを確認する
+      Assert.Throws<KeyNotFoundException>(() => url.Param["unknown"]);
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -70,6 +70,25 @@ namespace UnitTest
       Assert.Equal("example.com", url.Domain);
       Assert.Equal("http", url.Scheme);
       Assert.Equal("/path/to/api", url.LocalPath);
+
+      //パラメータの追加(プロパティ経由)
+      url.Param["key"] = "value";
+      Assert.Equal("value", url.Param["key"]);
+      Assert.Equal("http://example.com/path/to/api?key=value", url.Build());
+
+      //パラメータの追加(引数で)
+      var param = new Dictionary<string, string>() { {"foo", "bar"} };
+      Assert.Equal("http://example.com/path/to/api?key=value&foo=bar", url.Build(param));
+      Assert.Equal("http://example.com/path/to/api?key=value", url.Build());
+
+      //パラメータ削除
+      var array = new string[] { "key" };
+      Assert.Equal("http://example.com/path/to/api", url.Build(array));
+      Assert.Equal("http://example.com/path/to/api?key=value", url.Build());
+
+      var list = new List<string>() { "key" };
+      Assert.Equal("http://example.com/path/to/api", url.Build(list));
+      Assert.Equal("http://example.com/path/to/api?key=value", url.Build());
     }
 
     [Fact]
@@ -83,6 +102,25 @@ namespace UnitTest
       Assert.Equal("example.com", url.Domain);
       Assert.Equal("http", url.Scheme);
       Assert.Equal("/path/to/api", url.LocalPath);
+
+      //パラメータの追加(プロパティ経由)
+      url.Param["key"] = "value";
+      Assert.Equal("value", url.Param["key"]);
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build());
+
+      //パラメータの追加(引数で)
+      var param = new Dictionary<string, string>() { { "hoge", "fuga" } };
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value&hoge=fuga", url.Build(param));
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build());
+
+      //パラメータ削除
+      var array = new string[] { "key" };
+      Assert.Equal("http://example.com/path/to/api?foo=bar", url.Build(array));
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build());
+
+      var list = new List<string>() { "key" };
+      Assert.Equal("http://example.com/path/to/api?foo=bar", url.Build(list));
+      Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build());
     }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -259,5 +259,39 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue3", url.Build(addParam));
       Assert.Equal("http://example.com/path/to/api?sameKey=value0&sameKey=value1&sameKey=value2&newKey=newValue&newKey=newValue2", url.Build());
     }
+
+    [Fact]
+    public void TestNullCharValueParams()
+    {
+      var url = new Sdx.Web.Url("http://example.com/path/to/api?key=&key=&key=&foo=&foo=&foo=bar");
+
+      //Path
+      Assert.Equal("example.com", url.Domain);
+      Assert.Equal("http", url.Scheme);
+      Assert.Equal("/path/to/api", url.LocalPath);
+
+      //Param
+      Assert.Equal("", url.GetParam("key"));
+      Assert.Equal("bar", url.GetParam("foo"));
+
+      //ParamList
+      var keyList = url.GetParamList("key");
+      Assert.Equal("", keyList[0]);
+      Assert.Equal("", keyList[1]);
+      Assert.Equal("", keyList[2]);
+
+      var fooList = url.GetParamList("foo");
+      Assert.Equal("", fooList[0]);
+      Assert.Equal("", fooList[1]);
+      Assert.Equal("bar", fooList[2]);
+
+      //Null を Set
+      url.SetParam("key", null);
+      Assert.Equal("http://example.com/path/to/api?key=&key=&key=&foo=&foo=&foo=bar&key=", url.Build());
+
+      //空文字を Set
+      url.SetParam("foo", "");
+      Assert.Equal("http://example.com/path/to/api?key=&key=&key=&foo=&foo=&foo=bar&key=&foo=", url.Build());
+    }
   }
 }

--- a/UnitTest/UrlTest.cs
+++ b/UnitTest/UrlTest.cs
@@ -80,7 +80,7 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?foo=bar&hoge=huga&key=value", url.Build(unknownArray));
 
       //存在しない値を取得する
-      Assert.Equal(null, url.Param["unknown"]);
+      //Assert.Equal(null, url.Param["unknown"]);
     }
 
     [Fact]
@@ -136,7 +136,7 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?key=value", url.Build(unknownArray));
 
       //存在しない値を取得する
-      Assert.Equal(null, url.Param["unknown"]);
+      //Assert.Equal(null, url.Param["unknown"]);
     }
 
     [Fact]
@@ -192,7 +192,7 @@ namespace UnitTest
       Assert.Equal("http://example.com/path/to/api?foo=bar&key=value", url.Build(unknownArray));
 
       //存在しない値を取得する
-      Assert.Equal(null, url.Param["unknown"]);
+      //Assert.Equal(null, url.Param["unknown"]);
     }
   }
 }


### PR DESCRIPTION
## 概要
#21 のつづきです。

UnitTest にまだテストできていなかったケースをいくつか追加して、
必要に応じて実装側を修正するためのPRです。
## TODO
- [x] `TestMethod1()` の名前を意味のあるものに変更(テンプレートのままなので)
- [x] プロパティの記述方法変更([**フィールドの自動実装**](https://msdn.microsoft.com/ja-jp/library/bb384054.aspx) を使う)
- [x] テストケースの追加
  - 全テストに追加する
    - パラメータを追加(set)する
    - Buildの引数にパラメータ(Dictionary)を渡す
    - Buildの引数にパラメータ(Array)を渡す
    - 空のDictionary、key しかないDictionary を渡す
    - まだパラメータが何もセットされていない状態の Sdx.Web.Url に array や List を渡す
- [x] 他にも必要そうなテストが無いか検討する
- [x] 前項で決定したテストの追加
  - 詳細： https://github.com/SunriseDigital/cs-sdx/pull/24#issuecomment-142814610
    - 存在しない値を取得
    - 配列形式のクエリ文字列をセット
    - 値の無いクエリ文字列をセット(前述では `?key=` だったので、`?key` を試してみる)
- [x] 追加したテストに伴うコードの修正(必要に応じて適宜)
- [x] Sdx.Web.Url.Param の private 化
  - Get, Set メソッドを使うようにする。
- [x] ~~Sdx.Web.Url.Param を `Dictionary<string,string>` → `Dictionary<string,object>` に変更する。(同じキーで複数の値を持てるようにする)~~ Listで管理するように変更するためなし
- [x] Dictionary は追加した順番で取得できることは保証されていないため、List を使って保存するように変更する。
- [x] Get メソッドを配列、文字列の2パターン用意
- [x] Build メソッド周りの修正
- [x] 各 Get メソッドの挙動を検討する
- [x]  パラメータのリストを `List<KeyValuePair<string,string>>` で管理するように変更する
- [x] Set メソッドを上書き動作に修正
- [x] 追加のみを行うAddメソッドを別途作成する
- [x] パラメータを削除するメソッドも作成する
- [x] GetParam() は最初の要素の値を返すようにする
- [x] 特定のKeyに一致するValueの数を控えておき、Listで返すメソッド(GetParams)の中で必要な数だけループを行うようにする。
- [x] `List<KeyValuePair<string,string>>` を `List<Tuple<string,string>>` に変更
