### PR TITLE
GenericじゃないFetch

### DIFF
--- a/Sdx/Db/Connection.cs
+++ b/Sdx/Db/Connection.cs
@@ -471,6 +471,11 @@ namespace Sdx.Db
       return recordSet;
     }
 
+    /// <summary>
+    /// RecordSetの基点となるテーブルは最初にAddFromされた<see cref="Context" />です。
+    /// </summary>
+    /// <param name="select"></param>
+    /// <returns></returns>
     public RecordSet<Record> FetchRecordSet(Select select)
     {
       var firstFrom = select.ContextList.First((kv) => kv.Value.JoinType == JoinType.From).Value;

--- a/Sdx/Db/Connection.cs
+++ b/Sdx/Db/Connection.cs
@@ -446,6 +446,18 @@ namespace Sdx.Db
       return resultSet[0];
     }
 
+    public Record FetchRecord(Sql.Select select, string contextName)
+    {
+      var resultSet = this.FetchRecordSet(select, contextName);
+
+      if (resultSet.Count == 0)
+      {
+        return null;
+      }
+
+      return resultSet[0];
+    }
+
     /// <summary>
     /// SQLを実行しRecordSetを生成して返します。
     /// </summary>
@@ -469,37 +481,35 @@ namespace Sdx.Db
         throw new NotImplementedException("Initialize TableMeta for " + typeof(T));
       }
 
-      RecordSet<T> recordSet = null;
-      using (var command = select.Build())
-      {
-        recordSet = this.Fetch<RecordSet<T>>(command, (reader) =>
-        {
-          var resultSet = new RecordSet<T>();
-          resultSet.Build(reader, select, meta.Name);
-          return resultSet;
-        });
-      }
-
-      return recordSet;
+      return FetchRecordSet<T>(select, meta.Name);
     }
 
     /// <summary>
-    /// RecordSetの基点となるテーブルは最初にAddFromされた<see cref="Context" />です。
+    /// RecordSetの基点となるテーブルは最初にAddFromされた<see cref="Context"/>です。
     /// </summary>
     /// <param name="select"></param>
     /// <returns></returns>
     public RecordSet<Record> FetchRecordSet(Select select)
     {
       var firstFrom = select.ContextList.First((kv) => kv.Value.JoinType == JoinType.From).Value;
-      var meta = firstFrom.Table.OwnMeta;
 
-      RecordSet<Record> recordSet = null;
+      return FetchRecordSet<Record>(select, firstFrom.Name);
+    }
+
+    public RecordSet<Record> FetchRecordSet(Select select, string contextName)
+    {
+      return FetchRecordSet<Record>(select, contextName);
+    }
+
+    private RecordSet<T> FetchRecordSet<T>(Select select, string contextName) where T : Record, new()
+    {
+      RecordSet<T> recordSet = null;
       using (var command = select.Build())
       {
-        recordSet = this.Fetch<RecordSet<Record>>(command, (reader) =>
+        recordSet = this.Fetch<RecordSet<T>>(command, (reader) =>
         {
-          var resultSet = new RecordSet<Record>();
-          resultSet.Build(reader, select, meta.Name);
+          var resultSet = new RecordSet<T>();
+          resultSet.Build(reader, select, contextName);
           return resultSet;
         });
       }

--- a/Sdx/Db/Connection.cs
+++ b/Sdx/Db/Connection.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Data.Common;
 using System.Text;
 using Sdx.Db.Sql;
+using System.Linq;
 
 namespace Sdx.Db
 {
@@ -462,6 +463,25 @@ namespace Sdx.Db
         recordSet = this.Fetch<RecordSet<T>>(command, (reader) =>
         {
           var resultSet = new RecordSet<T>();
+          resultSet.Build(reader, select, meta.Name);
+          return resultSet;
+        });
+      }
+
+      return recordSet;
+    }
+
+    public RecordSet<Record> FetchRecordSet(Select select)
+    {
+      var firstFrom = select.ContextList.First((kv) => kv.Value.JoinType == JoinType.From).Value;
+      var meta = firstFrom.Table.OwnMeta;
+
+      RecordSet<Record> recordSet = null;
+      using (var command = select.Build())
+      {
+        recordSet = this.Fetch<RecordSet<Record>>(command, (reader) =>
+        {
+          var resultSet = new RecordSet<Record>();
           resultSet.Build(reader, select, meta.Name);
           return resultSet;
         });

--- a/Sdx/Db/Connection.cs
+++ b/Sdx/Db/Connection.cs
@@ -434,6 +434,18 @@ namespace Sdx.Db
       return resultSet[0];
     }
 
+    public Record FetchRecord(Sql.Select select)
+    {
+      var resultSet = this.FetchRecordSet(select);
+
+      if (resultSet.Count == 0)
+      {
+        return null;
+      }
+
+      return resultSet[0];
+    }
+
     /// <summary>
     /// SQLを実行しRecordSetを生成して返します。
     /// </summary>

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -343,6 +344,13 @@ namespace Sdx.Db.Sql
       return this.contextList.ContainsKey(contextName);
     }
 
+    public IEnumerable<KeyValuePair<string, Context>> ContextList
+    {
+      get
+      {
+        return contextList;
+      }
+    }
 
     /// <summary>
     /// From及びJoinしたテーブルの中からcontextNameのテーブルを探し返す

--- a/UnitTest/DbConnectionTest.cs
+++ b/UnitTest/DbConnectionTest.cs
@@ -491,7 +491,8 @@ namespace UnitTest
       using (var con = db.Adapter.CreateConnection())
       {
         string id = null;
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           id = con.FetchOne<string>(select);
         }));
         //connectionを開いてないので例外になるはず
@@ -508,7 +509,8 @@ namespace UnitTest
         var command = select.Build();
 
         string id = null;
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           id = con.FetchOne<string>(command);
         }));
         //connectionを開いてないので例外になるはず
@@ -546,7 +548,8 @@ namespace UnitTest
       {
         var command = sel.Build();
 
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           list = con.FetchList<string>(command);
         }));
         //connectionを開いてないので例外になるはず
@@ -573,7 +576,8 @@ namespace UnitTest
 
       using (var con = db.Adapter.CreateConnection())
       {
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           list = con.FetchList<string>(sel);
         }));
         //connectionを開いてないので例外になるはず
@@ -612,7 +616,8 @@ namespace UnitTest
       {
         Dictionary<string, string> strDic = null;
         var command = sel.Build();
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           strDic = con.FetchDictionary<string>(command);
         }));
         //connectionを開いてないので例外になるはず
@@ -640,7 +645,8 @@ namespace UnitTest
       using (var con = db.Adapter.CreateConnection())
       {
         Dictionary<string, object> objDic;
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           objDic = con.FetchDictionary<object>(sel);
         }));
         //connectionを開いてないので例外になるはず
@@ -679,7 +685,8 @@ namespace UnitTest
       using (var con = db.Adapter.CreateConnection())
       {
         var command = sel.Build();
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           list = con.FetchDictionaryList<string>(command);
         }));
         //connectionを開いてないので例外になるはず
@@ -706,7 +713,8 @@ namespace UnitTest
 
       using (var con = db.Adapter.CreateConnection())
       {
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           list = con.FetchDictionaryList<string>(sel);
         }));
         //connectionを開いてないので例外になるはず
@@ -745,7 +753,8 @@ namespace UnitTest
       using (var con = db.Adapter.CreateConnection())
       {
         var command = sel.Build();
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           list = con.FetchKeyValuePairList<int, string>(command);
         }));
         //connectionを開いてないので例外になるはず
@@ -773,7 +782,8 @@ namespace UnitTest
 
       using (var con = db.Adapter.CreateConnection())
       {
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           list = con.FetchKeyValuePairList<int, string>(sel);
         }));
         //connectionを開いてないので例外になるはず
@@ -809,7 +819,8 @@ namespace UnitTest
       using (var con = db.Adapter.CreateConnection())
       {
         Test.Orm.Shop shop;
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           shop = con.FetchRecord<Test.Orm.Shop>(sel);
         }));
         //connectionを開いてないので例外になるはず
@@ -823,15 +834,15 @@ namespace UnitTest
     }
 
     [Fact]
-    public void TestFetchRecordListWithConnection()
+    public void TestFetchRecordSetWithConnection()
     {
       foreach (TestDb db in this.CreateTestDbList())
       {
-        RunFetchRecordListWithConnection(db);
+        RunFetchRecordSetWithConnection(db);
       }
     }
 
-    private void RunFetchRecordListWithConnection(TestDb db)
+    private void RunFetchRecordSetWithConnection(TestDb db)
     {
       var sel = db.Adapter.CreateSelect();
       sel
@@ -844,7 +855,8 @@ namespace UnitTest
       using (var con = db.Adapter.CreateConnection())
       {
         Sdx.Db.RecordSet<Test.Orm.Shop> set;
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() => {
+        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
+        {
           set = con.FetchRecordSet<Test.Orm.Shop>(sel);
         }));
         //connectionを開いてないので例外になるはず
@@ -907,6 +919,38 @@ namespace UnitTest
       }
 
       context.DbProfiler = prevProfiler;
+    }
+
+    [Fact]
+    public void TestFetchRecordSetNonGeneric()
+    {
+      foreach (TestDb db in this.CreateTestDbList())
+      {
+        RunFetchRecordSetNonGeneric(db);
+      }
+    }
+
+    private void RunFetchRecordSetNonGeneric(TestDb db)
+    {
+      var sel = db.Adapter.CreateSelect();
+      sel
+        .AddFrom(new Test.Orm.Table.Shop())
+        .AddOrder("id", Sdx.Db.Sql.Order.DESC)
+        .Where
+          .Add("id", new string[] { "2", "3" })
+        ;
+
+      using (var con = db.Adapter.CreateConnection())
+      {
+        Sdx.Db.RecordSet<Sdx.Db.Record> set;
+        con.Open();
+        set = con.FetchRecordSet(sel);
+        Assert.Equal(2, set.Count);
+        Assert.Equal(3, set[0].GetInt32("id"));
+        Assert.Equal("天府舫", set[0].GetString("name"));
+        Assert.Equal(2, set[1].GetInt32("id"));
+        Assert.Equal("エスペリア", set[1].GetString("name"));
+      }
     }
   }
 }

--- a/UnitTest/DbConnectionTest.cs
+++ b/UnitTest/DbConnectionTest.cs
@@ -952,5 +952,31 @@ namespace UnitTest
         Assert.Equal("エスペリア", set[1].GetString("name"));
       }
     }
+
+    [Fact]
+    public void TestFetchRecordNonGeneric()
+    {
+      foreach (TestDb db in this.CreateTestDbList())
+      {
+        RunFetchRecordNonGeneric(db);
+      }
+    }
+
+    private void RunFetchRecordNonGeneric(TestDb db)
+    {
+      var sel = db.Adapter.CreateSelect();
+      sel
+        .AddFrom(new Test.Orm.Table.Shop())
+        .Where.Add("id", 1);
+
+      using (var con = db.Adapter.CreateConnection())
+      {
+        con.Open();
+        Sdx.Db.Record shop = con.FetchRecord(sel);
+        Assert.Equal(1, shop.GetInt32("id"));
+        Assert.Equal("天祥", shop.GetString("name"));
+      }
+    }
+
   }
 }


### PR DESCRIPTION
## 概要

Scaffoldを作っていて、動的にFetchするシチュエーションが結構あり、ジェネリックのメソッドをリフレクションを使って呼び出し、返り値をdynamicな変数に入れて扱っていたが、必要なのはTableMetaなので、実際にはRecordの具象クラスが必要ないことに気づいて、GenericじゃないFetchを作っています。
