### PR TITLE
ORDER BY NEWID() を実行できるようにする

### DIFF
--- a/Sdx/Db/Adapter/Base.cs
+++ b/Sdx/Db/Adapter/Base.cs
@@ -167,6 +167,6 @@ namespace Sdx.Db.Adapter
       return new Sql.Delete(this);
     }
 
-    internal abstract string RandomOrderKeyword { get; }
+    public abstract string RandomOrderKeyword { get; }
   }
 }

--- a/Sdx/Db/Adapter/Base.cs
+++ b/Sdx/Db/Adapter/Base.cs
@@ -166,5 +166,7 @@ namespace Sdx.Db.Adapter
     {
       return new Sql.Delete(this);
     }
+
+    internal abstract string RandomOrderKeyword { get; }
   }
 }

--- a/Sdx/Db/Adapter/MySql.cs
+++ b/Sdx/Db/Adapter/MySql.cs
@@ -49,5 +49,10 @@ namespace Sdx.Db.Adapter
       command.CommandText = "SELECT LAST_INSERT_ID()";
       return connection.ExecuteScalar(command);
     }
+
+    internal override string RandomOrderKeyword
+    {
+      get { return "RAND()"; }
+    }
   }
 }

--- a/Sdx/Db/Adapter/MySql.cs
+++ b/Sdx/Db/Adapter/MySql.cs
@@ -50,7 +50,7 @@ namespace Sdx.Db.Adapter
       return connection.ExecuteScalar(command);
     }
 
-    internal override string RandomOrderKeyword
+    public override string RandomOrderKeyword
     {
       get { return "RAND()"; }
     }

--- a/Sdx/Db/Adapter/SqlServer.cs
+++ b/Sdx/Db/Adapter/SqlServer.cs
@@ -53,7 +53,7 @@ namespace Sdx.Db.Adapter
       return connection.ExecuteScalar(command);
     }
 
-    internal override string RandomOrderKeyword
+    public override string RandomOrderKeyword
     {
       get { return "NEWID()"; }
     }

--- a/Sdx/Db/Adapter/SqlServer.cs
+++ b/Sdx/Db/Adapter/SqlServer.cs
@@ -52,5 +52,10 @@ namespace Sdx.Db.Adapter
       command.CommandText = "SELECT @@IDENTITY";
       return connection.ExecuteScalar(command);
     }
+
+    internal override string RandomOrderKeyword
+    {
+      get { return "NEWID()"; }
+    }
   }
 }

--- a/Sdx/Db/Sql/Column.cs
+++ b/Sdx/Db/Sql/Column.cs
@@ -14,7 +14,7 @@ namespace Sdx.Db.Sql
 
     internal string ContextName { get; set; }
 
-    internal Order Order { get; set; }
+    internal Order? Order { get; set; }
 
     internal object Value { get; set; }
 

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -330,8 +330,8 @@ namespace Sdx.Db.Sql
 
     public Context AddOrderRandom()
     {
-      var column = new Column(Expr.Wrap("NEWID()"));
-			column.Order = null;
+      var column = new Column(Expr.Wrap(Select.Adapter.RandomOrderKeyword));
+      column.Order = null;
       Select.OrderList.Add(column);
 
       return this;

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -328,6 +328,16 @@ namespace Sdx.Db.Sql
       return this;
     }
 
+    public Context AddOrderRandom()
+    {
+      var column = new Column(Expr.Wrap("NEWID()"));
+			column.Order = null;
+      Select.OrderList.Add(column);
+
+      return this;
+    }
+
+
     /// <summary>
     /// <see cref="Db.Table"/>を使ってFROM句/JOIN句に追加された<see cref="Context"/>からはこのプロパティーから<see cref="Db.Table"/>が取得できます。
     /// </summary>

--- a/Sdx/Db/Sql/Enums.cs
+++ b/Sdx/Db/Sql/Enums.cs
@@ -84,7 +84,7 @@ namespace Sdx.Db.Sql
       return strings[(int)gender];
     }
 
-    internal static string SqlString(this Order order)
+    internal static string SqlString(this Order? order)
     {
       string[] strings = { "ASC", "DESC" };
       return strings[(int)order];

--- a/Sdx/Db/Sql/Enums.cs
+++ b/Sdx/Db/Sql/Enums.cs
@@ -84,7 +84,7 @@ namespace Sdx.Db.Sql
       return strings[(int)gender];
     }
 
-    internal static string SqlString(this Order? order)
+    internal static string SqlString(this Order order)
     {
       string[] strings = { "ASC", "DESC" };
       return strings[(int)order];

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -595,6 +595,15 @@ namespace Sdx.Db.Sql
       return this;
     }
 
+    public Select AddOrderRandom()
+    {
+      var column = new Column(Expr.Wrap(Adapter.RandomOrderKeyword));
+      column.Order = null;
+      orders.Add(column);
+
+      return this;
+    }
+
     public object Clone()
     {
       var cloned = (Select)this.MemberwiseClone();

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -247,10 +247,16 @@ namespace Sdx.Db.Sql
           }
 
           builder
-            .Append(column.Build(this.Adapter, parameters, condCount))
-            .Append(" ")
-            .Append(column.Order.SqlString())
-            .Append(", ");
+            .Append(column.Build(this.Adapter, parameters, condCount));
+
+          if(column.Order != null)
+          {
+            builder
+              .Append(" ")
+              .Append(column.Order.SqlString());
+          }
+
+          builder.Append(", ");
         });
 
         builder.Remove(builder.Length - 2, 2);

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -251,9 +251,10 @@ namespace Sdx.Db.Sql
 
           if(column.Order != null)
           {
+            var sqlstr = ((Order)column.Order).SqlString();
             builder
               .Append(" ")
-              .Append(column.Order.SqlString());
+              .Append(sqlstr);
           }
 
           builder.Append(", ");

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2056,8 +2056,18 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
       var select = db.Adapter.CreateSelect();
       select
         .AddFrom(new Test.Orm.Table.Shop())
+        .SetColumn("id")
         .AddOrderRandom();
-      Assert.True(select.Build().CommandText.Contains("ORDER BY"));
+
+      db.Command = select.Build();
+
+      Assert.Equal(
+        db.Sql(
+          @"SELECT {0}shop{1}.{0}id{1} FROM {0}shop{1}
+          ORDER BY " + db.Adapter.RandomOrderKeyword
+        ),
+        db.Command.CommandText
+      );
     }
 
   }

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2040,5 +2040,25 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
         Assert.Equal(scSet.GroupBy(sc => sc.GetValue("shop_id")).Count(), count);
       }
     }
+
+    [Fact]
+    public void TestOrderRandom()
+    {
+      foreach (TestDb db in this.CreateTestDbList())
+      {
+        RunOrderRandom(db);
+        ExecSql(db);
+      }
+    }
+
+    private void RunOrderRandom(TestDb db)
+    {
+      var select = db.Adapter.CreateSelect();
+      select
+        .AddFrom(new Test.Orm.Table.Shop())
+        .AddOrderRandom();
+      Assert.True(select.Build().CommandText.Contains("ORDER BY"));
+    }
+
   }
 }


### PR DESCRIPTION
## 概要
`Sdx.Db.Sql.Select` では 現在は `ORDER BY {column} {ASC | DESC}` が可能ですが、
現状は必ずカラムの指定が必須 + ASC/DESC が付いてきてしまいます。
`ORDER BY NEWID()` のような SQL文は指定できないので、このPRで対応します。
とりあえずオーダーランダムのみ対応します。

### メモ

MySQLでいうところの `ORDER BY RAND()` を SQL server で実現する方法
http://stackoverflow.com/questions/19412/how-to-request-a-random-row-in-sql#answer-19419
