### PR TITLE
Releaseでのコンパイル時の環境変数ON_VISUAL_STUDIOを削除

### DIFF
--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;ON_VISUAL_STUDIO</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>


### PR DESCRIPTION
サーバー上でReleaseでコンパイルをする際に、UnitTestのビルドで多数のdllファイルが存在しないというエラーが出る。

ReleaseとDebug時に、ON_VISUAL_STUDIOという環境変数を利用して、VisualStudioがあると前提して、コンパイルを走らせる挙動を実現していて、サーバー上ではVisualStudioをインストールしないので、起こるエラーのようです。

Releaseでのコンパイルは、サーバー上では必ず行わなければならず、今回の問題を解決する為、ON_VISUAL_STUDIOの環境変数をコンパイル時に渡すを、Debugだけにする事になりました。

Debugでのコンパイル時は、今までと変わらずON_VISUAL_STUDIOを引数で渡しているので、ローカル等ではDebugでコンパイルすれば、今までどおりUnitTestの動作が動きつつ、コンパイルが実行される筈です。
