### PR TITLE
Contexts

### DIFF
--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -344,6 +344,14 @@ namespace Sdx.Db.Sql
       return this.contextList.ContainsKey(contextName);
     }
 
+    public IEnumerable<Context> Contexts
+    {
+      get
+      {
+        return contextList.Values;
+      }
+    }
+
     public IEnumerable<KeyValuePair<string, Context>> ContextList
     {
       get


### PR DESCRIPTION
selectStatUpToJoinsをこんな簡単な感じでかける

``` c#
    select.Contexts
      .Where(ctx => ctx.Table.OwnMeta.HasColumn("state"))
      .ForEach(ctx => ctx.Where.Add("state", Fzdb.Db.Const.StateUp));
```

ただ、これでもメソッドにまとめたほうが良いかもね。だとするとこのメソッドいらないか？ちなみに、無くてもこうかける。

``` c#
    select.ContextList
      .Where(kv => kv.Value.Table.OwnMeta.HasColumn("state"))
      .ForEach(kv => kv.Value.Where.Add("state", Fzdb.Db.Const.StateUp));
```

ContextListはKeyValuePairのEnumrableを返すのでコードになる。まあ、これでもいいか。
