### PR TITLE
Dateのフォーマットを外から変更できるように

### DIFF
--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -7,6 +7,7 @@ using System.Data;
 using Sdx.Db.Sql;
 using System.Collections.Specialized;
 using System.Web.Script.Serialization;
+using System.Globalization;
 
 namespace Sdx.Db
 {
@@ -482,10 +483,14 @@ namespace Sdx.Db
     /// <summary>
     /// FormにBindするためのNameValueCollectionを生成する。
     /// </summary>
-    /// <param name="dateFormat">ColumnType.Date型のカラムのフォーマット</param>
+    /// <param name="dateFormat">ColumnType.Date型のカラムのフォーマット。省略すると<see cref="CultureInfo.CurrentCulture"/>より取得。</param>
     /// <returns></returns>
-    public NameValueCollection ToNameValueCollection(string dateFormat = "yyyy/MM/dd")
+    public NameValueCollection ToNameValueCollection(string dateFormat = null)
     {
+      if (dateFormat == null)
+      {
+        dateFormat = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
+      }
       var col = new NameValueCollection();
       OwnMeta.Columns.ForEach((column) => {
         if (HasValue(column.Name))

--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -482,8 +482,9 @@ namespace Sdx.Db
     /// <summary>
     /// FormにBindするためのNameValueCollectionを生成する。
     /// </summary>
+    /// <param name="dateFormat">ColumnType.Date型のカラムのフォーマット</param>
     /// <returns></returns>
-    public NameValueCollection ToNameValueCollection()
+    public NameValueCollection ToNameValueCollection(string dateFormat = "yyyy/MM/dd")
     {
       var col = new NameValueCollection();
       OwnMeta.Columns.ForEach((column) => {
@@ -492,7 +493,7 @@ namespace Sdx.Db
           string value;
           if(column.Type == Table.ColumnType.Date)
           {
-            value = GetDateTime(column.Name).ToString("yyyy-MM-dd");
+            value = GetDateTime(column.Name).ToString(dateFormat);
           }
           else
           {

--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -483,21 +483,29 @@ namespace Sdx.Db
     /// <summary>
     /// FormにBindするためのNameValueCollectionを生成する。
     /// </summary>
-    /// <param name="dateFormat">ColumnType.Date型のカラムのフォーマット。省略すると<see cref="CultureInfo.CurrentCulture"/>より取得。</param>
+    /// <param name="dateFormat">ColumnType.Date|DateTime型のカラムのフォーマット。省略すると<see cref="CultureInfo.CurrentCulture"/>より取得。</param>
     /// <returns></returns>
     public NameValueCollection ToNameValueCollection(string dateFormat = null)
     {
-      if (dateFormat == null)
-      {
-        dateFormat = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
-      }
       var col = new NameValueCollection();
       OwnMeta.Columns.ForEach((column) => {
         if (HasValue(column.Name))
         {
           string value;
-          if(column.Type == Table.ColumnType.Date)
+          if (column.Type == Table.ColumnType.Date)
           {
+            if(dateFormat == null)
+            {
+              dateFormat = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
+            }
+            value = GetDateTime(column.Name).ToString(dateFormat);
+          }
+          else if(column.Type == Table.ColumnType.DateTime)
+          {
+            if(dateFormat == null)
+            {
+              dateFormat = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern + " " + CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern;
+            }
             value = GetDateTime(column.Name).ToString(dateFormat);
           }
           else


### PR DESCRIPTION
ToNameValueCollectionはフォームにRecordの値をBindする時に使います。

カラムがDate/DateTimeだった場合のフォーマットを外から変更できるようにしました。また、省略時はCultureInfo.CurrentCultureから取得します。

DateTimeのデフォルト値は

``` c#
CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern + " " + CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern
```

になります。
