### PR TITLE
Db関連の拡張

### DIFF
--- a/Sdx/Db/Connection.cs
+++ b/Sdx/Db/Connection.cs
@@ -530,6 +530,7 @@ namespace Sdx.Db
 
     public RecordSet FetchRecordSet(Select select, string contextName)
     {
+      select.Connection = this;
       RecordSet recordSet = null;
       using (var command = select.Build())
       {

--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -37,6 +37,14 @@ namespace Sdx.Db
       Init();
     }
 
+    protected Sdx.Db.Connection Connection
+    {
+      get
+      {
+        return Select.Connection;
+      }
+    }
+
     /// <summary>
     /// カラムが更新される直前に呼ばれるActionをセットする。<seealso cref="Init()"/>でセットしてください。
     /// ValueWillUpdate["someColumn"] = (prevValue, nextValue, isRaw) => {}
@@ -278,7 +286,7 @@ namespace Sdx.Db
       {
         if (connection == null)
         {
-          throw new ArgumentNullException("connection");
+          connection = Select.Connection;
         }
 
         if (OwnMeta.Relations.ContainsKey(contextName))

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -60,6 +60,24 @@ namespace Sdx.Db.Sql
       return joinContext;
     }
 
+    public Context InnerJoin(Table target, Condition condition, string alias, Action<Context> call)
+    {
+      call(InnerJoin(target, condition, alias));
+      return this;
+    }
+
+    public Context InnerJoin(Table target, Condition condition, Action<Context> call)
+    {
+      call(InnerJoin(target, condition));
+      return this;
+    }
+
+    public Context InnerJoin(Table target, Action<Context> call)
+    {
+      call(InnerJoin(target));
+      return this;
+    }
+
     public Context InnerJoin(Table target, Condition condition = null, string alias = null)
     {
       var context = this.AddJoin(target.OwnMeta.Name, JoinType.Inner, condition, alias);
@@ -94,6 +112,24 @@ namespace Sdx.Db.Sql
     public Context InnerJoin(string target, Condition condition, string alias = null)
     {
       return this.AddJoin(target, JoinType.Inner, condition, alias);
+    }
+
+    public Context LeftJoin(Table target, Condition condition, string alias, Action<Context> call)
+    {
+      call(LeftJoin(target, condition, alias));
+      return this;
+    }
+
+    public Context LeftJoin(Table target, Condition condition, Action<Context> call)
+    {
+      call(LeftJoin(target, condition));
+      return this;
+    }
+
+    public Context LeftJoin(Table target, Action<Context> call)
+    {
+      call(LeftJoin(target));
+      return this;
     }
 
     public Context LeftJoin(Sdx.Db.Table target, Condition condition = null, string alias = null)

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -650,5 +650,7 @@ namespace Sdx.Db.Sql
     {
       LimitPage(Pager.Page, Pager.PerPage);
     }
+
+    public Connection Connection { get; internal set; }
   }
 }

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -96,6 +96,18 @@ namespace Sdx.Db.Sql
     /// </summary>
     public JoinOrder JoinOrder { get; set; }
 
+    public Select AddFrom(Sdx.Db.Table target, Action<Context> call)
+    {
+      call(AddFrom(target));
+      return this;
+    }
+
+    public Select AddFrom(Sdx.Db.Table target, string alias, Action<Context> call)
+    {
+      call(AddFrom(target, alias));
+      return this;
+    }
+
     /// <summary>
     /// From句を追加。繰り返しコールすると繰り返し追加します。
     /// </summary>

--- a/UnitTest/Sdx/Db/Record.cs
+++ b/UnitTest/Sdx/Db/Record.cs
@@ -538,15 +538,7 @@ namespace UnitTest
 
         shop.ClearRecordCache();
 
-        //キャッシュがクリアされたのでConnectionなしだと例外に
-        Exception ex = Record.Exception(new Assert.ThrowsDelegate(() =>
-        {
-          var areaEx = shop.GetRecord("area");
-        }));
-
-        Assert.IsType<ArgumentNullException>(ex);
-
-        var area3 = shop.GetRecord("area", conn);
+        var area3 = shop.GetRecord("area");
         Assert.Equal(3, Sdx.Context.Current.DbProfiler.Logs.Where(log => log.CommandText.StartsWith("SELECT")).ToList().Count);
         Assert.NotEqual(area2, area3);
       }


### PR DESCRIPTION
## TODO
- [x] `conn.FetchRecord/FetchRecordSet`時にSelectにConnectionを保持させて、その後のGetRecord/GetRecordSetで使いまわせるようにする。
- [x] AddFrom/InnerJoin/LeftJoinにラムダを渡してSelect生成を見やすくする。
- [x] RelationにContextNameを渡して同じテーブルのJOINをできるようにする。
