### PR TITLE
番号付きページ送り機能

### DIFF
--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -119,8 +119,8 @@ namespace Sdx.Html
     public List<Tag> GetLinksTag(int number)
     {
       var links = new List<Tag>(){};
-      Pager.GetPageDataList(number).ForEach(ph => {
-        var linkTag = CrateLinkTag(ph.IsCurrent ? null : ph.Id.ToString()).AddText(ph.Id.ToString());
+      Pager.GetPageDataList(number).ForEach(pd => {
+        var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString()).AddText(pd.Id.ToString());
         links.Add(linkTag);
       });
 

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -115,5 +115,16 @@ namespace Sdx.Html
     {
       return CrateLinkTag(Pager.Page == Pager.LastPage ? null : Pager.LastPage.ToString());
     }
+
+    public List<Tag> GetLinksTag(int number)
+    {
+      var links = new List<Tag>(){};
+      Pager.GetPageHolderList(number).ForEach(ph => {
+        var linkTag = CrateLinkTag(ph.is_current ? null : ph.number.ToString()).AddText(ph.number.ToString());
+        links.Add(linkTag);
+      });
+
+      return links;
+    }
   }
 }

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -120,7 +120,7 @@ namespace Sdx.Html
     {
       var links = new List<Tag>(){};
       Pager.GetPageDataList(number).ForEach(ph => {
-        var linkTag = CrateLinkTag(ph.is_current ? null : ph.number.ToString()).AddText(ph.number.ToString());
+        var linkTag = CrateLinkTag(ph.IsCurrent ? null : ph.Id.ToString()).AddText(ph.Id.ToString());
         links.Add(linkTag);
       });
 

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -12,6 +12,8 @@ namespace Sdx.Html
 
     private string varName;
 
+    private string classNameForDisabled = "disabled";
+
     public PagerLink(Pager pager, Web.Url baseUrl, string varName)
     {
       Pager = pager;
@@ -89,7 +91,7 @@ namespace Sdx.Html
       else
       {
         tag = new Tag("span");
-        tag.Attr.AddClass("disabled");
+        tag.Attr.AddClass(classNameForDisabled);
       }
 
       return tag;
@@ -118,12 +120,10 @@ namespace Sdx.Html
 
     public List<Tag> GetLinksTag(int number)
     {
+      classNameForDisabled = "current_page";
       var links = new List<Tag>(){};
       Pager.GetPageDataList(number).ForEach(pd => {
         var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());
-        if(pd.IsCurrent && linkTag.Attr.HasClass("disable")) {
-          linkTag.Attr.RemoveClass("disable").AddClass("current_page");
-        }
         linkTag.AddText(pd.Id.ToString());
         links.Add(linkTag);
       });
@@ -133,14 +133,10 @@ namespace Sdx.Html
 
     public List<Tag> GetLinksTag(int number, Func<string, string> func)
     {
+      classNameForDisabled = "current_page";
       var links = new List<Tag>() { };
-      Pager.GetPageDataList(number).ForEach(pd =>
-      {
+      Pager.GetPageDataList(number).ForEach(pd => {
         var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());
-        if (pd.IsCurrent && linkTag.Attr.HasClass("disable"))
-        {
-          linkTag.Attr.RemoveClass("disable").AddClass("current_page");
-        }
         linkTag.AddText(func(pd.Id.ToString()));
         links.Add(linkTag);
       });

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -119,7 +119,7 @@ namespace Sdx.Html
     public List<Tag> GetLinksTag(int number)
     {
       var links = new List<Tag>(){};
-      Pager.GetPageHolderList(number).ForEach(ph => {
+      Pager.GetPageDataList(number).ForEach(ph => {
         var linkTag = CrateLinkTag(ph.is_current ? null : ph.number.ToString()).AddText(ph.number.ToString());
         links.Add(linkTag);
       });

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -120,15 +120,7 @@ namespace Sdx.Html
 
     public List<Tag> GetLinksTag(int number)
     {
-      classNameForDisabled = "current";
-      var links = new List<Tag>(){};
-      Pager.GetPageDataList(number).ForEach(pd => {
-        var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());
-        linkTag.AddText(pd.Id.ToString());
-        links.Add(linkTag);
-      });
-
-      return links;
+      return GetLinksTag(number, num => num);
     }
 
     public List<Tag> GetLinksTag(int number, Func<string, string> func)

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -120,7 +120,20 @@ namespace Sdx.Html
     {
       var links = new List<Tag>(){};
       Pager.GetPageDataList(number).ForEach(pd => {
-        var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString()).AddText(pd.Id.ToString());
+        var url = (Web.Url)BaseUrl.Clone();
+        Html.Tag linkTag;
+        if (pd.IsCurrent)
+        {
+          linkTag = new Tag("span");
+          linkTag.Attr.AddClass("current_page");
+        }
+        else
+        {
+          url.SetParam(VarName, pd.Id.ToString());
+          linkTag = new Tag("a");
+          linkTag.Attr.Set("href", url.Build());
+        }
+        linkTag.AddText(pd.Id.ToString());
         links.Add(linkTag);
       });
 

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -130,5 +130,22 @@ namespace Sdx.Html
 
       return links;
     }
+
+    public List<Tag> GetLinksTag(int number, Func<string, string> func)
+    {
+      var links = new List<Tag>() { };
+      Pager.GetPageDataList(number).ForEach(pd =>
+      {
+        var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());
+        if (pd.IsCurrent && linkTag.Attr.HasClass("disable"))
+        {
+          linkTag.Attr.RemoveClass("disable").AddClass("current_page");
+        }
+        linkTag.AddText(func(pd.Id.ToString()));
+        links.Add(linkTag);
+      });
+
+      return links;
+    }
   }
 }

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -137,7 +137,7 @@ namespace Sdx.Html
       var links = new List<Tag>() { };
       Pager.GetPageDataList(number).ForEach(pd => {
         var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());
-        linkTag.AddText(func(pd.Id.ToString()));
+        linkTag.AddText(func(pd.Id.ToString()), false);
         links.Add(linkTag);
       });
 

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -120,7 +120,7 @@ namespace Sdx.Html
 
     public List<Tag> GetLinksTag(int number)
     {
-      classNameForDisabled = "current_page";
+      classNameForDisabled = "current";
       var links = new List<Tag>(){};
       Pager.GetPageDataList(number).ForEach(pd => {
         var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());
@@ -133,7 +133,7 @@ namespace Sdx.Html
 
     public List<Tag> GetLinksTag(int number, Func<string, string> func)
     {
-      classNameForDisabled = "current_page";
+      classNameForDisabled = "current";
       var links = new List<Tag>() { };
       Pager.GetPageDataList(number).ForEach(pd => {
         var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());

--- a/Sdx/Html/PagerLink.cs
+++ b/Sdx/Html/PagerLink.cs
@@ -120,18 +120,9 @@ namespace Sdx.Html
     {
       var links = new List<Tag>(){};
       Pager.GetPageDataList(number).ForEach(pd => {
-        var url = (Web.Url)BaseUrl.Clone();
-        Html.Tag linkTag;
-        if (pd.IsCurrent)
-        {
-          linkTag = new Tag("span");
-          linkTag.Attr.AddClass("current_page");
-        }
-        else
-        {
-          url.SetParam(VarName, pd.Id.ToString());
-          linkTag = new Tag("a");
-          linkTag.Attr.Set("href", url.Build());
+        var linkTag = CrateLinkTag(pd.IsCurrent ? null : pd.Id.ToString());
+        if(pd.IsCurrent && linkTag.Attr.HasClass("disable")) {
+          linkTag.Attr.RemoveClass("disable").AddClass("current_page");
         }
         linkTag.AddText(pd.Id.ToString());
         links.Add(linkTag);

--- a/Sdx/Pager.cs
+++ b/Sdx/Pager.cs
@@ -147,8 +147,17 @@ namespace Sdx
 
     public class PageData
     {
-      public bool is_current;
-      public int number;
+      public bool IsCurrent
+      {
+        get;
+        set;
+      }
+
+      public int Id
+      {
+        get;
+        set;
+      }
     }
 
     public List<PageData> GetPageDataList(int number)
@@ -170,8 +179,8 @@ namespace Sdx
         if (HasPage(i))
         {
           var pageData = new PageData();
-          pageData.number = i;
-          pageData.is_current = (Page == i) ? true : false;
+          pageData.Id = i;
+          pageData.IsCurrent = (Page == i) ? true : false;
           pageDataList.Add(pageData);
         }
       }

--- a/Sdx/Pager.cs
+++ b/Sdx/Pager.cs
@@ -167,13 +167,21 @@ namespace Sdx
       var pageHolderList = new List<PageHolder>(){};
       for(var i = start; i < number + start; i++)
       {
-        var pageHolder = new PageHolder();
-        pageHolder.number = i;
-        pageHolder.is_current = (Page == i) ? true : false;
-        pageHolderList.Add(pageHolder);
+        if (HasPage(i))
+        {
+          var pageHolder = new PageHolder();
+          pageHolder.number = i;
+          pageHolder.is_current = (Page == i) ? true : false;
+          pageHolderList.Add(pageHolder);
+        }
       }
 
       return pageHolderList;
+    }
+
+    public bool HasPage(int page)
+    {
+      return (page >= 1 && page <= LastPage) ? true : false;
     }
 
 

--- a/Sdx/Pager.cs
+++ b/Sdx/Pager.cs
@@ -159,7 +159,7 @@ namespace Sdx
       {
         start = 1;
       }
-      if(start > LastPage - number + 1)
+      else if(start > LastPage - number + 1)
       {
         start = LastPage - number + 1;
       }

--- a/Sdx/Pager.cs
+++ b/Sdx/Pager.cs
@@ -190,7 +190,7 @@ namespace Sdx
 
     public bool HasPage(int page)
     {
-      return (page >= 1 && page <= LastPage) ? true : false;
+      return (page >= 1 && page <= LastPage);
     }
 
 

--- a/Sdx/Pager.cs
+++ b/Sdx/Pager.cs
@@ -150,13 +150,13 @@ namespace Sdx
       public bool IsCurrent
       {
         get;
-        set;
+        internal set;
       }
 
       public int Id
       {
         get;
-        set;
+        internal set;
       }
     }
 

--- a/Sdx/Pager.cs
+++ b/Sdx/Pager.cs
@@ -144,5 +144,38 @@ namespace Sdx
         return true;
       }
     }
+
+    public class PageHolder
+    {
+      public bool is_current;
+      public int number;
+    }
+
+    public List<PageHolder> GetPageHolderList(int number)
+    {
+      var tmp = (int)number/2;
+      var start = Page - tmp;
+      if(start < 1)
+      {
+        start = 1;
+      }
+      if(start > LastPage - number + 1)
+      {
+        start = LastPage - number + 1;
+      }
+
+      var pageHolderList = new List<PageHolder>(){};
+      for(var i = start; i < number + start; i++)
+      {
+        var pageHolder = new PageHolder();
+        pageHolder.number = i;
+        pageHolder.is_current = (Page == i) ? true : false;
+        pageHolderList.Add(pageHolder);
+      }
+
+      return pageHolderList;
+    }
+
+
   }
 }

--- a/Sdx/Pager.cs
+++ b/Sdx/Pager.cs
@@ -145,13 +145,13 @@ namespace Sdx
       }
     }
 
-    public class PageHolder
+    public class PageData
     {
       public bool is_current;
       public int number;
     }
 
-    public List<PageHolder> GetPageHolderList(int number)
+    public List<PageData> GetPageDataList(int number)
     {
       var tmp = (int)number/2;
       var start = Page - tmp;
@@ -164,19 +164,19 @@ namespace Sdx
         start = LastPage - number + 1;
       }
 
-      var pageHolderList = new List<PageHolder>(){};
+      var pageDataList = new List<PageData>(){};
       for(var i = start; i < number + start; i++)
       {
         if (HasPage(i))
         {
-          var pageHolder = new PageHolder();
-          pageHolder.number = i;
-          pageHolder.is_current = (Page == i) ? true : false;
-          pageHolderList.Add(pageHolder);
+          var pageData = new PageData();
+          pageData.number = i;
+          pageData.is_current = (Page == i) ? true : false;
+          pageDataList.Add(pageData);
         }
       }
 
-      return pageHolderList;
+      return pageDataList;
     }
 
     public bool HasPage(int page)

--- a/Sdx/Pager.md
+++ b/Sdx/Pager.md
@@ -67,3 +67,15 @@ CSファイル側は前項と同じ記述でOKです。
   </div>
 </div>
 ```
+
+#### aspx記述例(2)
+`GetLinksTag()` の引数にコールバックを渡すこともできます。
+aタグの中身を数字以外にしたい場合などに使えます。
+下記は画像をaタグの中に表示させたい場合の例です。
+```asp
+<div class="link-list">
+  <% foreach(var link in pager_link.GetLinksTag(5, page => {string.Format(@"<img src='/path/to/img/{0}.jpg alt='{0}' />", page)})) { %>
+    <%= link.Render() %>
+  <% } %>
+</div>
+```

--- a/Sdx/Pager.md
+++ b/Sdx/Pager.md
@@ -42,3 +42,28 @@ select.LimitPager(pager);
   </div>
 </div>
 ```
+
+### 番号付きのページャー
+こういうタイプのページングを生成する例です
+```
+[←前へ][1][2][3][4][5][次へ→]
+```
+
+#### aspx記述例
+CSファイル側は前項と同じ記述でOKです。
+```asp
+<div class="row">
+  <div class="text-center">
+    <%= pagerLink.GetPrev().AddText("←前へ").Render() %>
+    
+    <div class="link-list">
+      <%-- GetLinksTag の引数分だけリンクタグが生成されます  --%>
+      <% foreach(var link in pager_link.GetLinksTag(5)) { %>
+        <%= link.Render() %>
+      <% } %>
+    </div>
+
+    <%= pagerLink.GetNext().AddText("次へ→").Render() %>
+  </div>
+</div>
+```

--- a/UnitTest/Sdx/Html/PagerLink.cs
+++ b/UnitTest/Sdx/Html/PagerLink.cs
@@ -27,7 +27,7 @@ namespace UnitTest
       var pagerLink = new Sdx.Html.PagerLink(pager, baseUrl, "pid");
 
       var links = pagerLink.GetLinksTag(5);
-      Assert.Equal("<span class=\"current_page\">11</span>", links[2].Render());
+      Assert.Equal("<span class=\"current\">11</span>", links[2].Render());
       Assert.Equal("<a href=\"/path/to/target/page?pid=12\">12</a>", links[3].Render());
     }
 
@@ -41,7 +41,7 @@ namespace UnitTest
       var pagerLink = new Sdx.Html.PagerLink(pager, baseUrl, "pid");
 
       var links = pagerLink.GetLinksTag(5, page => string.Format("<b>{0}</b>", page));
-      Assert.Equal("<span class=\"current_page\"><b>11</b></span>", links[2].Render());
+      Assert.Equal("<span class=\"current\"><b>11</b></span>", links[2].Render());
       Assert.Equal("<a href=\"/path/to/target/page?pid=12\"><b>12</b></a>", links[3].Render());
     }
   }

--- a/UnitTest/Sdx/Html/PagerLink.cs
+++ b/UnitTest/Sdx/Html/PagerLink.cs
@@ -30,5 +30,19 @@ namespace UnitTest
       Assert.Equal("<span class=\"current_page\">11</span>", links[2].Render());
       Assert.Equal("<a href=\"/path/to/target/page?pid=12\">12</a>", links[3].Render());
     }
+
+    [Fact]
+    public void TestLinksTagCallBack()
+    {
+      InitHttpContextMock("pid=11");
+      var pager = new Sdx.Pager(10, 200);
+      pager.SetPage("11");
+      var baseUrl = new Sdx.Web.Url("/path/to/target/page");
+      var pagerLink = new Sdx.Html.PagerLink(pager, baseUrl, "pid");
+
+      var links = pagerLink.GetLinksTag(5, page => string.Format("<b>{0}</b>", page));
+      Assert.Equal("<span class=\"current_page\"><b>11</b></span>", links[2].Render());
+      Assert.Equal("<a href=\"/path/to/target/page?pid=12\"><b>12</b></a>", links[3].Render());
+    }
   }
 }

--- a/UnitTest/Sdx/Html/PagerLink.cs
+++ b/UnitTest/Sdx/Html/PagerLink.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+using UnitTest.DummyClasses;
+
+#if ON_VISUAL_STUDIO
+using FactAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
+using TestClassAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+using ClassInitializeAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute;
+using ClassCleanupAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute;
+using TestContext = Microsoft.VisualStudio.TestTools.UnitTesting.TestContext;
+#endif
+
+using System;
+using System.Collections.Generic;
+
+namespace UnitTest
+{
+  [TestClass]
+  public class Html_PagerLink : BaseTest
+  {
+    [Fact]
+    public void TestBuildShortcut()
+    {
+
+    }
+  }
+}

--- a/UnitTest/Sdx/Html/PagerLink.cs
+++ b/UnitTest/Sdx/Html/PagerLink.cs
@@ -27,7 +27,7 @@ namespace UnitTest
       var pagerLink = new Sdx.Html.PagerLink(pager, baseUrl, "pid");
 
       var links = pagerLink.GetLinksTag(5);
-      Assert.Equal("<span class=\"disabled\">11</span>", links[2].Render());
+      Assert.Equal("<span class=\"current_page\">11</span>", links[2].Render());
       Assert.Equal("<a href=\"/path/to/target/page?pid=12\">12</a>", links[3].Render());
     }
   }

--- a/UnitTest/Sdx/Html/PagerLink.cs
+++ b/UnitTest/Sdx/Html/PagerLink.cs
@@ -18,9 +18,17 @@ namespace UnitTest
   public class Html_PagerLink : BaseTest
   {
     [Fact]
-    public void TestBuildShortcut()
+    public void TestLinksTag()
     {
+      InitHttpContextMock("pid=11");
+      var pager = new Sdx.Pager(10, 200);
+      pager.SetPage("11");
+      var baseUrl = new Sdx.Web.Url("/path/to/target/page");
+      var pagerLink = new Sdx.Html.PagerLink(pager, baseUrl, "pid");
 
+      var links = pagerLink.GetLinksTag(5);
+      Assert.Equal("<span class=\"disabled\">11</span>", links[2].Render());
+      Assert.Equal("<a href=\"/path/to/target/page?pid=12\">12</a>", links[3].Render());
     }
   }
 }

--- a/UnitTest/Sdx/Pager.cs
+++ b/UnitTest/Sdx/Pager.cs
@@ -213,7 +213,7 @@ namespace UnitTest
       Assert.Equal(12, idList[4]);
       Assert.Equal(true, isCurrentList[4]);
 
-      //GetPageHolderList に総ページ数より多い数を渡した場合
+      //GetPageDataList に総ページ数より多い数を渡した場合
       pager.SetPage("12");
       Assert.Equal(12, pager.GetPageDataList(20).Count);
     }

--- a/UnitTest/Sdx/Pager.cs
+++ b/UnitTest/Sdx/Pager.cs
@@ -102,9 +102,10 @@ namespace UnitTest
       var numberList = new List<int>(){};
       var isCurrentList = new List<bool>(){};
 
-      pager.GetPages(5).ForEach(page => {
-        numberList.Add(page.page);
-        isCurrentList.Add(page.is_current);
+      //奇数パターン
+      pager.GetPageHolderList(5).ForEach(ph => {
+        numberList.Add(ph.number);
+        isCurrentList.Add(ph.is_current);
       });
 
       Assert.Equal(3, numberList[0]);
@@ -118,6 +119,99 @@ namespace UnitTest
       Assert.Equal(true, isCurrentList[2]);
       Assert.Equal(false, isCurrentList[3]);
       Assert.Equal(false, isCurrentList[4]);
+
+      //偶数パターン
+      numberList.Clear();
+      isCurrentList.Clear();
+      pager.GetPageHolderList(6).ForEach(ph =>
+      {
+        numberList.Add(ph.number);
+        isCurrentList.Add(ph.is_current);
+      });
+
+      Assert.Equal(2, numberList[0]);
+      Assert.Equal(3, numberList[1]);
+      Assert.Equal(4, numberList[2]);
+      Assert.Equal(5, numberList[3]);
+      Assert.Equal(6, numberList[4]);
+      Assert.Equal(7, numberList[5]);
+
+      Assert.Equal(false, isCurrentList[0]);
+      Assert.Equal(false, isCurrentList[1]);
+      Assert.Equal(false, isCurrentList[2]);
+      Assert.Equal(true, isCurrentList[3]);
+      Assert.Equal(false, isCurrentList[4]);
+      Assert.Equal(false, isCurrentList[5]);
+
+      //奇数だが真ん中が現在のページにできないパターン(1)
+      numberList.Clear();
+      isCurrentList.Clear();
+      pager.SetPage("2");
+      pager.GetPageHolderList(5).ForEach(ph =>
+      {
+        numberList.Add(ph.number);
+        isCurrentList.Add(ph.is_current);
+      });
+
+      Assert.Equal(1, numberList[0]);
+      Assert.Equal(2, numberList[1]);
+      Assert.Equal(3, numberList[2]);
+      Assert.Equal(4, numberList[3]);
+      Assert.Equal(5, numberList[4]);
+
+      Assert.Equal(false, isCurrentList[0]);
+      Assert.Equal(true, isCurrentList[1]);
+      Assert.Equal(false, isCurrentList[2]);
+      Assert.Equal(false, isCurrentList[3]);
+      Assert.Equal(false, isCurrentList[4]);
+
+      //奇数だが真ん中が現在のページにできないパターン(2)
+      numberList.Clear();
+      isCurrentList.Clear();
+      pager.SetPage("11");
+      pager.GetPageHolderList(5).ForEach(ph =>
+      {
+        numberList.Add(ph.number);
+        isCurrentList.Add(ph.is_current);
+      });
+
+      Assert.Equal(8, numberList[0]);
+      Assert.Equal(9, numberList[1]);
+      Assert.Equal(10, numberList[2]);
+      Assert.Equal(11, numberList[3]);
+      Assert.Equal(12, numberList[4]);
+
+      Assert.Equal(false, isCurrentList[0]);
+      Assert.Equal(false, isCurrentList[1]);
+      Assert.Equal(false, isCurrentList[2]);
+      Assert.Equal(true, isCurrentList[3]);
+      Assert.Equal(false, isCurrentList[4]);
+
+      //現在のページが先頭のページ
+      numberList.Clear();
+      isCurrentList.Clear();
+      pager.SetPage("1");
+      pager.GetPageHolderList(5).ForEach(ph =>
+      {
+        numberList.Add(ph.number);
+        isCurrentList.Add(ph.is_current);
+      });
+
+      Assert.Equal(1, numberList[0]);
+      Assert.Equal(true, isCurrentList[0]);
+
+      //現在のページが最後のページ
+      numberList.Clear();
+      isCurrentList.Clear();
+      pager.SetPage("12");
+      pager.GetPageHolderList(5).ForEach(ph =>
+      {
+        numberList.Add(ph.number);
+        isCurrentList.Add(ph.is_current);
+      });
+
+      Assert.Equal(12, numberList[4]);
+      Assert.Equal(true, isCurrentList[4]);
     }
   }
 }

--- a/UnitTest/Sdx/Pager.cs
+++ b/UnitTest/Sdx/Pager.cs
@@ -212,6 +212,10 @@ namespace UnitTest
 
       Assert.Equal(12, numberList[4]);
       Assert.Equal(true, isCurrentList[4]);
+
+      //GetPageHolderList に総ページ数より多い数を渡した場合
+      pager.SetPage("12");
+      Assert.Equal(12, pager.GetPageHolderList(20).Count);
     }
   }
 }

--- a/UnitTest/Sdx/Pager.cs
+++ b/UnitTest/Sdx/Pager.cs
@@ -99,20 +99,20 @@ namespace UnitTest
       var pager = new Sdx.Pager(perPage, totalCount);
       pager.SetPage("5");
 
-      var numberList = new List<int>(){};
+      var idList = new List<int>(){};
       var isCurrentList = new List<bool>(){};
 
       //奇数パターン
       pager.GetPageDataList(5).ForEach(pd => {
-        numberList.Add(pd.number);
-        isCurrentList.Add(pd.is_current);
+        idList.Add(pd.Id);
+        isCurrentList.Add(pd.IsCurrent);
       });
 
-      Assert.Equal(3, numberList[0]);
-      Assert.Equal(4, numberList[1]);
-      Assert.Equal(5, numberList[2]);
-      Assert.Equal(6, numberList[3]);
-      Assert.Equal(7, numberList[4]);
+      Assert.Equal(3, idList[0]);
+      Assert.Equal(4, idList[1]);
+      Assert.Equal(5, idList[2]);
+      Assert.Equal(6, idList[3]);
+      Assert.Equal(7, idList[4]);
 
       Assert.Equal(false, isCurrentList[0]);
       Assert.Equal(false, isCurrentList[1]);
@@ -121,20 +121,20 @@ namespace UnitTest
       Assert.Equal(false, isCurrentList[4]);
 
       //偶数パターン
-      numberList.Clear();
+      idList.Clear();
       isCurrentList.Clear();
       pager.GetPageDataList(6).ForEach(pd =>
       {
-        numberList.Add(pd.number);
-        isCurrentList.Add(pd.is_current);
+        idList.Add(pd.Id);
+        isCurrentList.Add(pd.IsCurrent);
       });
 
-      Assert.Equal(2, numberList[0]);
-      Assert.Equal(3, numberList[1]);
-      Assert.Equal(4, numberList[2]);
-      Assert.Equal(5, numberList[3]);
-      Assert.Equal(6, numberList[4]);
-      Assert.Equal(7, numberList[5]);
+      Assert.Equal(2, idList[0]);
+      Assert.Equal(3, idList[1]);
+      Assert.Equal(4, idList[2]);
+      Assert.Equal(5, idList[3]);
+      Assert.Equal(6, idList[4]);
+      Assert.Equal(7, idList[5]);
 
       Assert.Equal(false, isCurrentList[0]);
       Assert.Equal(false, isCurrentList[1]);
@@ -144,20 +144,20 @@ namespace UnitTest
       Assert.Equal(false, isCurrentList[5]);
 
       //奇数だが真ん中が現在のページにできないパターン(1)
-      numberList.Clear();
+      idList.Clear();
       isCurrentList.Clear();
       pager.SetPage("2");
       pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(pd.number);
-        isCurrentList.Add(pd.is_current);
+        idList.Add(pd.Id);
+        isCurrentList.Add(pd.IsCurrent);
       });
 
-      Assert.Equal(1, numberList[0]);
-      Assert.Equal(2, numberList[1]);
-      Assert.Equal(3, numberList[2]);
-      Assert.Equal(4, numberList[3]);
-      Assert.Equal(5, numberList[4]);
+      Assert.Equal(1, idList[0]);
+      Assert.Equal(2, idList[1]);
+      Assert.Equal(3, idList[2]);
+      Assert.Equal(4, idList[3]);
+      Assert.Equal(5, idList[4]);
 
       Assert.Equal(false, isCurrentList[0]);
       Assert.Equal(true, isCurrentList[1]);
@@ -166,20 +166,20 @@ namespace UnitTest
       Assert.Equal(false, isCurrentList[4]);
 
       //奇数だが真ん中が現在のページにできないパターン(2)
-      numberList.Clear();
+      idList.Clear();
       isCurrentList.Clear();
       pager.SetPage("11");
       pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(pd.number);
-        isCurrentList.Add(pd.is_current);
+        idList.Add(pd.Id);
+        isCurrentList.Add(pd.IsCurrent);
       });
 
-      Assert.Equal(8, numberList[0]);
-      Assert.Equal(9, numberList[1]);
-      Assert.Equal(10, numberList[2]);
-      Assert.Equal(11, numberList[3]);
-      Assert.Equal(12, numberList[4]);
+      Assert.Equal(8, idList[0]);
+      Assert.Equal(9, idList[1]);
+      Assert.Equal(10, idList[2]);
+      Assert.Equal(11, idList[3]);
+      Assert.Equal(12, idList[4]);
 
       Assert.Equal(false, isCurrentList[0]);
       Assert.Equal(false, isCurrentList[1]);
@@ -188,29 +188,29 @@ namespace UnitTest
       Assert.Equal(false, isCurrentList[4]);
 
       //現在のページが先頭のページ
-      numberList.Clear();
+      idList.Clear();
       isCurrentList.Clear();
       pager.SetPage("1");
       pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(pd.number);
-        isCurrentList.Add(pd.is_current);
+        idList.Add(pd.Id);
+        isCurrentList.Add(pd.IsCurrent);
       });
 
-      Assert.Equal(1, numberList[0]);
+      Assert.Equal(1, idList[0]);
       Assert.Equal(true, isCurrentList[0]);
 
       //現在のページが最後のページ
-      numberList.Clear();
+      idList.Clear();
       isCurrentList.Clear();
       pager.SetPage("12");
       pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(pd.number);
-        isCurrentList.Add(pd.is_current);
+        idList.Add(pd.Id);
+        isCurrentList.Add(pd.IsCurrent);
       });
 
-      Assert.Equal(12, numberList[4]);
+      Assert.Equal(12, idList[4]);
       Assert.Equal(true, isCurrentList[4]);
 
       //GetPageHolderList に総ページ数より多い数を渡した場合

--- a/UnitTest/Sdx/Pager.cs
+++ b/UnitTest/Sdx/Pager.cs
@@ -103,9 +103,9 @@ namespace UnitTest
       var isCurrentList = new List<bool>(){};
 
       //奇数パターン
-      pager.GetPageHolderList(5).ForEach(ph => {
-        numberList.Add(ph.number);
-        isCurrentList.Add(ph.is_current);
+      pager.GetPageDataList(5).ForEach(pd => {
+        numberList.Add(pd.number);
+        isCurrentList.Add(pd.is_current);
       });
 
       Assert.Equal(3, numberList[0]);
@@ -123,10 +123,10 @@ namespace UnitTest
       //偶数パターン
       numberList.Clear();
       isCurrentList.Clear();
-      pager.GetPageHolderList(6).ForEach(ph =>
+      pager.GetPageDataList(6).ForEach(pd =>
       {
-        numberList.Add(ph.number);
-        isCurrentList.Add(ph.is_current);
+        numberList.Add(pd.number);
+        isCurrentList.Add(pd.is_current);
       });
 
       Assert.Equal(2, numberList[0]);
@@ -147,10 +147,10 @@ namespace UnitTest
       numberList.Clear();
       isCurrentList.Clear();
       pager.SetPage("2");
-      pager.GetPageHolderList(5).ForEach(ph =>
+      pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(ph.number);
-        isCurrentList.Add(ph.is_current);
+        numberList.Add(pd.number);
+        isCurrentList.Add(pd.is_current);
       });
 
       Assert.Equal(1, numberList[0]);
@@ -169,10 +169,10 @@ namespace UnitTest
       numberList.Clear();
       isCurrentList.Clear();
       pager.SetPage("11");
-      pager.GetPageHolderList(5).ForEach(ph =>
+      pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(ph.number);
-        isCurrentList.Add(ph.is_current);
+        numberList.Add(pd.number);
+        isCurrentList.Add(pd.is_current);
       });
 
       Assert.Equal(8, numberList[0]);
@@ -191,10 +191,10 @@ namespace UnitTest
       numberList.Clear();
       isCurrentList.Clear();
       pager.SetPage("1");
-      pager.GetPageHolderList(5).ForEach(ph =>
+      pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(ph.number);
-        isCurrentList.Add(ph.is_current);
+        numberList.Add(pd.number);
+        isCurrentList.Add(pd.is_current);
       });
 
       Assert.Equal(1, numberList[0]);
@@ -204,10 +204,10 @@ namespace UnitTest
       numberList.Clear();
       isCurrentList.Clear();
       pager.SetPage("12");
-      pager.GetPageHolderList(5).ForEach(ph =>
+      pager.GetPageDataList(5).ForEach(pd =>
       {
-        numberList.Add(ph.number);
-        isCurrentList.Add(ph.is_current);
+        numberList.Add(pd.number);
+        isCurrentList.Add(pd.is_current);
       });
 
       Assert.Equal(12, numberList[4]);
@@ -215,7 +215,7 @@ namespace UnitTest
 
       //GetPageHolderList に総ページ数より多い数を渡した場合
       pager.SetPage("12");
-      Assert.Equal(12, pager.GetPageHolderList(20).Count);
+      Assert.Equal(12, pager.GetPageDataList(20).Count);
     }
   }
 }

--- a/UnitTest/Sdx/Pager.cs
+++ b/UnitTest/Sdx/Pager.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Globalization;
 using System.Reflection;
+using System.Collections.Generic;
 
 #if ON_VISUAL_STUDIO
 using FactAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
@@ -88,6 +89,35 @@ namespace UnitTest
       Assert.Equal(5, pager.Page);
       Assert.False(pager.HasNext);
       Assert.True(pager.HasPrev);
+    }
+
+    [Fact]
+    public void TestPages()
+    {
+      var perPage = 3;
+      var totalCount = 35;
+      var pager = new Sdx.Pager(perPage, totalCount);
+      pager.SetPage("5");
+
+      var numberList = new List<int>(){};
+      var isCurrentList = new List<bool>(){};
+
+      pager.GetPages(5).ForEach(page => {
+        numberList.Add(page.page);
+        isCurrentList.Add(page.is_current);
+      });
+
+      Assert.Equal(3, numberList[0]);
+      Assert.Equal(4, numberList[1]);
+      Assert.Equal(5, numberList[2]);
+      Assert.Equal(6, numberList[3]);
+      Assert.Equal(7, numberList[4]);
+
+      Assert.Equal(false, isCurrentList[0]);
+      Assert.Equal(false, isCurrentList[1]);
+      Assert.Equal(true, isCurrentList[2]);
+      Assert.Equal(false, isCurrentList[3]);
+      Assert.Equal(false, isCurrentList[4]);
     }
   }
 }

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Sdx\Db\Sql\Insert.cs" />
     <Compile Include="Sdx\Diagnostics\Debug.cs" />
     <Compile Include="DummyClasses.cs" />
+    <Compile Include="Sdx\Html\PagerLink.cs" />
     <Compile Include="Sdx\Html\Tag.cs" />
     <Compile Include="Sdx\Html\Attr.cs" />
     <Compile Include="Sdx\Html\Form.cs" />


### PR DESCRIPTION
## 概要

今までのページャーはこうだった
```
[←前へ]  [次へ→]
```

こういうのを作れるようにしたい。
```
[←前へ] [1][2][3][4][5] [次へ→]
```
## TODO

※随時追加
- [x] Pager にページ情報を持つ内部クラスを追加する
- [x] PagerLink に上記内部クラスを使ってリンクタグを作るメソッドを追加する
- [x] マニュアル追加
- [x] 総ページ数より多い数を返せるのを修正する
- [x] 動作チェックなど
- レビュー後修正作業
  - [x] PageHolderの名前を変更
  - [x] メンバ変数をプロパティに変更
  - [x] 不要な三項演算子をカット
  - [x] `<span>` タグに付与するクラス属性の変更
  - [x] GetLinksTag にコールバックを渡せるようにする
  - [x] PageData クラスのプロパティは get 以外はアクセス制限する
  - [x] GetLinksTag メソッドの重複コードを排除する
  - [x] current_page ---> current に変更
