### PR TITLE
空のリストがセットされてもエラーにならないように実装

### DIFF
--- a/Sdx/Db/Sql/Condition.cs
+++ b/Sdx/Db/Sql/Condition.cs
@@ -22,6 +22,7 @@ namespace Sdx.Db.Sql
       public Column Column { get; set; }
       public object Value { get; set; }
       public Type Type { get; set; }
+      public bool IsEmtpyValue { get; set; }
     }
 
     private List<Holder> wheres = new List<Holder>();
@@ -308,7 +309,16 @@ namespace Sdx.Db.Sql
           condCount.Incr();
         }
 
-        rightHand = "(" + inCond + ")";
+        //IEnumerableが空だった
+        if (inCond.Length == 0)
+        {
+          cond.IsEmtpyValue = true;
+          rightHand = "('EMPTY')";
+        }
+        else
+        {
+          rightHand = "(" + inCond + ")";
+        }
       }
       else
       {
@@ -325,12 +335,25 @@ namespace Sdx.Db.Sql
       if (cond.Type == Type.Comparison)
       {
         var value = this.BuildPlaceholderAndParameters(adapter, parameters, cond, condCount);
-        return String.Format(
-          "{0}{1}{2}",
-          cond.Column.Build(adapter, parameters, condCount),
-          cond.Comparison.SqlString(),
-          value
-        );
+        if(cond.IsEmtpyValue)
+        {
+          return String.Format(
+            "'{0}@{1}'{2}{3}",
+            cond.Column.Name,
+            cond.Column.ContextName,
+            cond.Comparison.SqlString(),
+            value
+          );
+        }
+        else
+        {
+          return String.Format(
+            "{0}{1}{2}",
+            cond.Column.Build(adapter, parameters, condCount),
+            cond.Comparison.SqlString(),
+            value
+          );
+        }
       }
       else if(cond.Type == Type.NullCompare)
       {

--- a/Sdx/Db/Table.cs
+++ b/Sdx/Db/Table.cs
@@ -348,7 +348,7 @@ namespace Sdx.Db
       return conn.FetchRecord(select);
     }
 
-    public Record FetchRecordByPkey(Db.Connection conn, string pkeyValue)
+    public Record FetchRecordByPkey(Db.Connection conn, object pkeyValue)
     {
       if (OwnMeta.Pkeys.Count() > 1)
       {


### PR DESCRIPTION
## 概要

```c#
      var db = testDb.Adapter;
      var select = db.CreateSelect();

      select.AddFrom(new Test.Orm.Table.Shop(), cShop =>
      {
        cShop.SetColumns("id");
        cShop.Where.Add("id", new List<int>());
      });
```

こんな感じで空っぽのIEnumrableが来るとエラーになっていたので修正しました。INの時は何も引っかからないように、NOT INの時はその条件を無視するようになっています。

## 別件
うっかり、関係ない変更をこのブランチにコミットしたけど、まあ一緒にアップされても問題ないと思うのでこのまま行きます。

具体的には、Table.FetchRecordByPkeyの引数をstringからobjectに変更しました。

https://github.com/SunriseDigital/cs-sdx/blob/432b3d5354b3a9cf27d9036df525698d46887948/Sdx/Db/Table.cs#L351