### PR TITLE
Cast文を安全に追加する。

### DIFF
--- a/Sdx/Db/Sql/Cast.cs
+++ b/Sdx/Db/Sql/Cast.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sdx.Db.Sql
+{
+  public class Cast
+  {
+    public string Column { get; private set; }
+
+    public string Type { get; private set; }
+
+    public Cast(string column, string type)
+    {
+      Column = column;
+      Type = type;
+    }
+  }
+}

--- a/Sdx/Db/Sql/Column.cs
+++ b/Sdx/Db/Sql/Column.cs
@@ -50,6 +50,13 @@ namespace Sdx.Db.Sql
       Alias = alias;
     }
 
+    public Column(Cast cast, string contextName = null, string alias = null)
+    {
+      target = cast;
+      ContextName = contextName;
+      Alias = alias;
+    }
+
     public object Target
     {
       get { return this.target; }
@@ -88,13 +95,28 @@ namespace Sdx.Db.Sql
     internal string Build(Adapter.Base db, DbParameterCollection parameters, Counter condCount)
     {
       var sql = "";
-      if(this.ContextName != null)
+      if(target is Cast)
       {
-        sql = db.QuoteIdentifier(this.ContextName) + "." + this.QuotedName(db, parameters, condCount);
+        var cast = target as Cast;
+        if (this.ContextName != null)
+        {
+          sql = string.Format("CAST({0}.{1} as {2})");
+        }
+        else
+        {
+          sql = sql = string.Format("CAST({0} as {1})");
+        }
       }
       else
       {
-        sql = this.QuotedName(db, parameters, condCount);
+        if (this.ContextName != null)
+        {
+          sql = db.QuoteIdentifier(this.ContextName) + "." + this.QuotedName(db, parameters, condCount);
+        }
+        else
+        {
+          sql = this.QuotedName(db, parameters, condCount);
+        }
       }
 
       if(this.Alias != null)

--- a/Sdx/Db/Sql/Condition.cs
+++ b/Sdx/Db/Sql/Condition.cs
@@ -73,6 +73,13 @@ namespace Sdx.Db.Sql
       return this;
     }
 
+    public Condition AddCast(string column, string type, object value, Comparison comparison = Comparison.Equal)
+    {
+      var cast = new Cast(column, type);
+      this.AddWithColumn(new Column(cast, this.ContextName), value, Logical.And, comparison, Type.Comparison);
+      return this;
+    }
+
     public Condition Add(string column, Object value, Comparison comparison = Comparison.Equal)
     {
       this.AddWithColumn(new Column(column, this.ContextName), value, Logical.And, comparison, Type.Comparison);

--- a/Sdx/Sdx.csproj
+++ b/Sdx/Sdx.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Db\Adapter\Manager.cs" />
     <Compile Include="Db\Connection.cs" />
     <Compile Include="Db\DbException.cs" />
+    <Compile Include="Db\Sql\Cast.cs" />
     <Compile Include="Db\Sql\ContextActions.cs" />
     <Compile Include="Db\Sql\INonQueryBuilder.cs" />
     <Compile Include="Db\Adapter\MySql.cs" />


### PR DESCRIPTION
CAST文を安全に生成する仕組みを作ろうと思ったが、型名が穴になるので、ENUMかなにかで持たさないとダメでベンダーの差異をどのように吸収するか検討が必要になったため、一旦保留。