### PR TITLE
予約文字を含めたURLエンコード

### DIFF
--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -104,7 +104,7 @@ namespace Sdx.Util
 
       if (isEnableReservedChar)
       {
-        string reservedChars = "!*'();:@&=+$,/?#[]";
+        string reservedChars = "!()_-*.";
 
         var sb = new StringBuilder();
 

--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -99,6 +99,9 @@ namespace Sdx.Util
     /// <returns></returns>
     public static string UrlEncode(string str, bool isEnableReservedChar = false)
     {
+      // !()_-*.以外の文字列がエンコードされます
+      str = HttpUtility.UrlEncode(str);
+
       if (isEnableReservedChar)
       {
         string reservedChars = "!*'();:@&=+$,/?#[]";
@@ -119,7 +122,7 @@ namespace Sdx.Util
         str = sb.ToString();
       }
 
-      return HttpUtility.UrlEncode(str);
+      return str;
     }
   }
 }

--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 
 namespace Sdx.Util
 {
@@ -117,7 +118,7 @@ namespace Sdx.Util
         }
       }
 
-      return UrlEncode(str);
+      return HttpUtility.UrlEncode(str);
     }
   }
 }

--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -100,21 +100,20 @@ namespace Sdx.Util
     {
       if (enableReservedChar)
       {
-        string reservedChar = "!*'();:@&=+$,/?#[]";
+        string reservedChars = "!*'();:@&=+$,/?#[]";
         //reservedChar += "%";
 
         var sb = new StringBuilder();
 
         foreach (char @char in str)
         {
-          if (reservedChar.IndexOf(@char) == -1)
+          if (reservedChars.IndexOf(@char) == -1)
           {
             sb.Append(@char);
+            continue;
           }
-          else
-          {
-            sb.AppendFormat("%{0:X2}", (int)@char);
-          }
+
+          sb.AppendFormat("%{0:X2}", (int)@char);
         }
       }
 

--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -96,9 +96,9 @@ namespace Sdx.Util
     /// <param name="str"></param>
     /// <param name="enableReservedChar"></param>
     /// <returns></returns>
-    public static string UrlEncode(string str, bool enableReservedChar = false)
+    public static string UrlEncode(string str, bool isEnableReservedChar = false)
     {
-      if (enableReservedChar)
+      if (isEnableReservedChar)
       {
         string reservedChars = "!*'();:@&=+$,/?#[]";
         //reservedChar += "%";

--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -89,6 +89,13 @@ namespace Sdx.Util
       return new string(value.Select( chr => (fullWidthNumberlist.ContainsKey(chr) ? fullWidthNumberlist[chr] : chr )).ToArray());
     }
 
+    /// <summary>
+    /// QRコードを読むアプリケーションで正規表現が正しく機能せずリンクが生成されないケースがある為
+    /// 本来はURLエンコードの必要のない記号（予約文字）も含めてエンコードします
+    /// </summary>
+    /// <param name="str"></param>
+    /// <param name="enableReservedChar"></param>
+    /// <returns></returns>
     public static string UrlEncode(string str, bool enableReservedChar = false)
     {
       if (enableReservedChar)

--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -102,7 +102,6 @@ namespace Sdx.Util
       if (isEnableReservedChar)
       {
         string reservedChars = "!*'();:@&=+$,/?#[]";
-        //reservedChar += "%";
 
         var sb = new StringBuilder();
 
@@ -116,6 +115,8 @@ namespace Sdx.Util
 
           sb.AppendFormat("%{0:X2}", (int)@char);
         }
+
+        str = sb.ToString();
       }
 
       return HttpUtility.UrlEncode(str);

--- a/Sdx/Util/String.cs
+++ b/Sdx/Util/String.cs
@@ -88,5 +88,30 @@ namespace Sdx.Util
     {
       return new string(value.Select( chr => (fullWidthNumberlist.ContainsKey(chr) ? fullWidthNumberlist[chr] : chr )).ToArray());
     }
+
+    public static string UrlEncode(string str, bool enableReservedChar = false)
+    {
+      if (enableReservedChar)
+      {
+        string reservedChar = "!*'();:@&=+$,/?#[]";
+        //reservedChar += "%";
+
+        var sb = new StringBuilder();
+
+        foreach (char @char in str)
+        {
+          if (reservedChar.IndexOf(@char) == -1)
+          {
+            sb.Append(@char);
+          }
+          else
+          {
+            sb.AppendFormat("%{0:X2}", (int)@char);
+          }
+        }
+      }
+
+      return UrlEncode(str);
+    }
   }
 }


### PR DESCRIPTION
## 概要

スマホのQRを読むアプリケーションで正規表現が正しく機能しないケースがあり、リンクが生成されない為、本来はURLエンコードの必要のない記号（予約文字）も含めてエンコードするメソッドを作成します