### PR TITLE
Itemの持つTreeに対応するレコードが、複数タイプある場合に対応出来なかったので改修

### DIFF
--- a/Sdx/Data/TreeMapper/Record.cs
+++ b/Sdx/Data/TreeMapper/Record.cs
@@ -22,15 +22,28 @@ namespace Sdx.Data.TreeMapper
             Condition = condition;
         }
 
+        public IEnumerable<Sdx.Data.TreeMapper.Record.Item> GetItems()
+        {
+            foreach (var childTree in Tree.List)
+            {
+                yield return CreateItem(childTree);
+            }
+        }
+
         public IEnumerable<Sdx.Data.TreeMapper.Record.Item> GetItems(string key)
         {
             foreach (var childTree in Tree.Get(key).List)
             {
-                var treeItem = new T();
-                treeItem.Tree = childTree;
-                treeItem.Record = RecordSet.Select(rec => (R)rec).FirstOrDefault(rec => this.Condition(treeItem, rec));
-                yield return treeItem;
+                yield return CreateItem(childTree);
             }
+        }
+
+        private T CreateItem(Tree childTree)
+        {
+            var treeItem = new T();
+            treeItem.Tree = childTree;
+            treeItem.AddRecord("Shop", RecordSet.Select(rec => (R)rec).FirstOrDefault(rec => this.Condition(treeItem, rec)));
+            return treeItem;
         }
     }
 }

--- a/Sdx/Data/TreeMapper/Record.cs
+++ b/Sdx/Data/TreeMapper/Record.cs
@@ -12,13 +12,14 @@ namespace Sdx.Data.TreeMapper
         where R : Sdx.Db.Record
     {
         private Tree Tree;
-        private Sdx.Db.RecordSet RecordSet;
+        private Dictionary<string, Sdx.Db.RecordSet> RecordSetDictionary;
+        private string RecordKey;
         private Func<T, R, bool> Condition;
 
-        public Record(Tree tree, Sdx.Db.RecordSet recordSet, Func<T, R, bool> condition)
+        public Record(Tree tree, Dictionary<string, Sdx.Db.RecordSet> recordSetList, Func<T, R, bool> condition)
         {
             Tree = tree;
-            RecordSet = recordSet;
+            RecordSetDictionary = recordSetList;
             Condition = condition;
         }
 
@@ -42,7 +43,11 @@ namespace Sdx.Data.TreeMapper
         {
             var treeItem = new T();
             treeItem.Tree = childTree;
-            treeItem.AddRecord("Shop", RecordSet.Select(rec => (R)rec).FirstOrDefault(rec => this.Condition(treeItem, rec)));
+            foreach (KeyValuePair<string, Sdx.Db.RecordSet> pair in RecordSetDictionary)
+            {
+              treeItem.AddRecord(pair.Key, pair.Value.Select(rec => (R)rec).FirstOrDefault(rec => this.Condition(treeItem, rec)));
+            }
+
             return treeItem;
         }
     }

--- a/Sdx/Data/TreeMapper/Record/Item.cs
+++ b/Sdx/Data/TreeMapper/Record/Item.cs
@@ -8,33 +8,12 @@ namespace Sdx.Data.TreeMapper.Record
 {
     public class Item
     {
-        private Tree ChildTree;
-        private Sdx.Db.Record TreeRecord;
+        public Tree Tree { get; set; }
+        protected Dictionary<string, Sdx.Db.Record> TreeRecords;
 
-        public Tree Tree
+        public void AddRecord(string key, Sdx.Db.Record record)
         {
-            get
-            {
-                return ChildTree;
-            }
-
-            set
-            {
-                ChildTree = value;
-            }
-        }
-
-        public Sdx.Db.Record Record
-        {
-            get
-            {
-                return TreeRecord;
-            }
-
-            set
-            {
-                TreeRecord =  value;
-            }
+            TreeRecords.Add(key, record);
         }
     }
 }


### PR DESCRIPTION
・Dictionaryでキー、レコードを保持し、同じTreeに対して、複数タイプのレコードを持てるようにしました。
・各タイプのレコードは、一つのみなのは変えていません。