### PR TITLE
Itemの持つTreeに対応するレコードが、複数タイプある場合に対応出来なかったので改修 / レビュー後修正

### DIFF
--- a/Sdx/Data/TreeMapper/Record/Item.cs
+++ b/Sdx/Data/TreeMapper/Record/Item.cs
@@ -8,17 +8,22 @@ namespace Sdx.Data.TreeMapper.Record
 {
     public class Item
     {
-        public Tree Tree { get; set; }
-        protected Dictionary<string, Sdx.Db.Record> TreeRecords = null;
+        protected Dictionary<string, Sdx.Db.Record> treeRecords = null;
+        protected Sdx.Data.Tree tree = null;
+
+        public void AddTree(Sdx.Data.Tree tree)
+        {
+          this.tree = tree;
+        }
 
         public void AddRecord(string key, Sdx.Db.Record record)
         {
-          if (TreeRecords== null)
+          if (treeRecords == null)
           {
-            TreeRecords = new Dictionary<string,Db.Record>{};
+            treeRecords = new Dictionary<string, Db.Record> { };
           }
-          
-          TreeRecords.Add(key, record);
+
+          treeRecords.Add(key, record);
         }
     }
 }


### PR DESCRIPTION
レビューで出た修正点を直しました。

### 修正点
・変数名が大文字始まりにしてしまっていたので修正
・複数のレコードセットを、Treeに対応させる際の、条件文は、1つしか渡せなかったので、それぞれのレコードセットに対応させる条件をセット出来るように変更。
・内部クラス内にデータを条件、レコードセット等を持ち、対応するTreeに対して、今まで通り、TreeMapper.Record.ItemにTree・Recordをセットする流れです。
