### PR TITLE
リレーションテーブルの存在チェックの改善とAliasの自動付与の修正

### DIFF
--- a/Sdx/Db/Connection.cs
+++ b/Sdx/Db/Connection.cs
@@ -524,7 +524,11 @@ namespace Sdx.Db
     /// <returns></returns>
     public RecordSet FetchRecordSet(Sql.Select select)
     {
-      var firstFrom = select.ContextList.First((kv) => kv.Value.JoinType == JoinType.From).Value;
+      var firstFrom = select.ContextList.FirstOrDefault((kv) => kv.Value.JoinType == JoinType.From).Value;
+      if (firstFrom == null)
+      {
+        throw new InvalidOperationException("Missing from clause in table list [" + select.Contexts.Select(ctx => ctx.Name).Aggregate((prev, next) => prev + "," + next) + "]");
+      }
       return FetchRecordSet(select, firstFrom.Name);
     }
 

--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -275,7 +275,11 @@ namespace Sdx.Db
     private string GetRelationName<T>()
     {
       var recordType = typeof(T);
-      var relations = OwnMeta.Relations.Where(kv => kv.Value.TableMeta.RecordType == recordType);
+      var relations = OwnMeta.Relations.Where(kv => kv.Value.TableMeta.RecordType == recordType || kv.Value.TableMeta.RecordType.IsSubclassOf(recordType));
+      if (relations.Count() == 0)
+      {
+        relations = OwnMeta.Relations.Where(kv => kv.Value.TableMeta.RecordType == recordType);
+      }
       var count = relations.Count();
       if (count == 0)
       {

--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -275,11 +275,7 @@ namespace Sdx.Db
     private string GetRelationName<T>()
     {
       var recordType = typeof(T);
-      var relations = OwnMeta.Relations.Where(kv => kv.Value.TableMeta.RecordType == recordType || kv.Value.TableMeta.RecordType.IsSubclassOf(recordType));
-      if (relations.Count() == 0)
-      {
-        relations = OwnMeta.Relations.Where(kv => kv.Value.TableMeta.RecordType == recordType);
-      }
+      var relations = OwnMeta.Relations.Where(kv => recordType.IsAssignableFrom(kv.Value.TableMeta.RecordType));
       var count = relations.Count();
       if (count == 0)
       {

--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -276,14 +276,14 @@ namespace Sdx.Db
     {
       var recordType = typeof(T);
       var relations = OwnMeta.Relations.Where(kv => recordType.IsAssignableFrom(kv.Value.TableMeta.RecordType));
+      //if(candidates.Any() && !candidates.Skip(1).Any())
+      //とも書けるが、3つ以上同じテーブルのリレーションを張る可能性が極めて低く、また、Countの方が直感的で読みやすい。
+      //ベンチもとってみた。
+      //https://github.com/SunriseDigital/cs-sdx/pull/134#issuecomment-323269774
       var count = relations.Count();
-      if (count == 0)
+      if (count != 1)
       {
-        throw new NotImplementedException("Missing relation setting for " + recordType + " in " + OwnMeta.TableType);
-      }
-      else if (count > 1)
-      {
-        throw new NotImplementedException("Too many match relations for " + recordType + " in " + OwnMeta.TableType);
+        throw new InvalidOperationException("Unable to uniquely identify the relation in " + OwnMeta.Name + " for " + recordType);
       }
 
       return relations.First().Key;

--- a/Sdx/Db/Record.cs
+++ b/Sdx/Db/Record.cs
@@ -373,8 +373,10 @@ namespace Sdx.Db
 
           var sel = connection.Adapter.CreateSelect();
           sel.SetComment(this.GetType().Name + "::GetRecordSet(" + contextName  + ")");
-          sel.AddFrom(relations.TableMeta.CreateTable())
-            .Where.Add(relations.ReferenceKey, this.GetString(relations.ForeignKey));
+          sel.AddFrom(relations.TableMeta.CreateTable(), contextName, context =>
+          {
+            context.Where.Add(relations.ReferenceKey, this.GetString(relations.ForeignKey));
+          });
 
           if (selectHook != null)
           {

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -16,31 +16,11 @@ namespace Sdx.Db.Sql
       this.Select = select;
     }
 
-    private object target;
     /// <summary>
     /// 対象のテーブルまたはサブクエリー。型は
     /// <see cref="string"/>|<see cref="Expr"/>|<see cref="Sql.Select"/>です。
     /// </summary>
-    public object Target
-    { 
-      get
-      {
-        return target;
-      }
-
-      internal set
-      {
-        target = value;
-        if (target is String && Alias == null)
-        {
-          var tableName = (String)target;
-          if (tableName.Contains("."))
-          {
-            Alias = tableName.Replace('.', '$');
-          }
-        }
-      }
-    }
+    public object Target { get; internal set; }
 
     public string Alias { get; internal set; }
 

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -17,11 +17,24 @@ namespace Sdx.Db.Sql
       this.Select = select;
     }
 
+    private object target;
     /// <summary>
     /// 対象のテーブルまたはサブクエリー。型は
     /// <see cref="string"/>|<see cref="Expr"/>|<see cref="Sql.Select"/>です。
     /// </summary>
-    public object Target { get; internal set; }
+    public object Target
+    {
+      get
+      {
+        return target;
+      }
+
+      set
+      {
+        target = value;
+        Sdx.Context.Current.Debug.Log(target);
+      }
+    }
 
     public string Alias { get; internal set; }
 
@@ -87,6 +100,10 @@ namespace Sdx.Db.Sql
 
     public Context InnerJoin(Table target, Condition condition = null, string alias = null)
     {
+      if (alias == null)
+      {
+        alias = target.OwnMeta.DefaultAlias;
+      }
       var context = this.AddJoin(target.OwnMeta.Name, JoinType.Inner, condition, alias);
       context.Table = target;
 
@@ -180,8 +197,12 @@ namespace Sdx.Db.Sql
       return this;
     }
 
-    public Context LeftJoin(Sdx.Db.Table target, Condition condition = null, string alias = null)
+    public Context LeftJoin(Table target, Condition condition = null, string alias = null)
     {
+      if (alias == null)
+      {
+        alias = target.OwnMeta.DefaultAlias;
+      }
       var context = this.AddJoin(target.OwnMeta.Name, JoinType.Left, condition, alias);
       context.Table = target;
 

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -220,7 +220,12 @@ namespace Sdx.Db.Sql
       else if (targetContext.Table != null)
       {
         var candidates = Table.OwnMeta.Relations.Where(rel => rel.Value.TableType.IsAssignableFrom(targetContext.Table.GetType()));
-        if (candidates.Any())
+        //if(candidates.Any() && !candidates.Skip(1).Any())
+        //とも書けるが、3つ以上同じテーブルのリレーションを張る可能性が極めて低く、また、Countの方が直感的で読みやすい。
+        //ベンチもとってみた。
+        //https://github.com/SunriseDigital/cs-sdx/pull/134#issuecomment-323269774
+        var count = candidates.Count();
+        if (count == 1)
         {
           relation = candidates.First().Value;
         }
@@ -228,7 +233,7 @@ namespace Sdx.Db.Sql
 
       if (relation == null)
       {
-        throw new KeyNotFoundException("Unable to uniquely identify the relation in " + this.Name + " for " + targetContext.Name);
+        throw new InvalidOperationException("Unable to uniquely identify the relation in " + this.Name + " for " + targetContext.Name);
       }
 
       cond.Add(

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -22,19 +22,7 @@ namespace Sdx.Db.Sql
     /// 対象のテーブルまたはサブクエリー。型は
     /// <see cref="string"/>|<see cref="Expr"/>|<see cref="Sql.Select"/>です。
     /// </summary>
-    public object Target
-    {
-      get
-      {
-        return target;
-      }
-
-      set
-      {
-        target = value;
-        Sdx.Context.Current.Debug.Log(target);
-      }
-    }
+    public object Target { get; internal set; }
 
     public string Alias { get; internal set; }
 

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -16,11 +16,31 @@ namespace Sdx.Db.Sql
       this.Select = select;
     }
 
+    private object target;
     /// <summary>
     /// 対象のテーブルまたはサブクエリー。型は
     /// <see cref="string"/>|<see cref="Expr"/>|<see cref="Sql.Select"/>です。
     /// </summary>
-    public object Target { get; internal set; }
+    public object Target
+    { 
+      get
+      {
+        return target;
+      }
+
+      internal set
+      {
+        target = value;
+        if (target is String && Alias == null)
+        {
+          var tableName = (String)target;
+          if (tableName.Contains("."))
+          {
+            Alias = tableName.Replace('.', '$');
+          }
+        }
+      }
+    }
 
     public string Alias { get; internal set; }
 

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -38,7 +38,14 @@ namespace Sdx.Db.Sql
           return this.Alias;
         }
 
-        return this.Target.ToString(); 
+        string name = this.Target.ToString();
+
+        if (typeof(String) == name.GetType())
+        {
+          name = name.Replace(".", "@");
+        }
+
+        return name;
       }
     }
 

--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -38,14 +38,7 @@ namespace Sdx.Db.Sql
           return this.Alias;
         }
 
-        string name = this.Target.ToString();
-
-        if (typeof(String) == name.GetType())
-        {
-          name = name.Replace(".", "@");
-        }
-
-        return name;
+        return this.Target.ToString(); 
       }
     }
 

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -113,6 +113,10 @@ namespace Sdx.Db.Sql
     /// </summary>
     public Context AddFrom(Sdx.Db.Table target, string alias = null)
     {
+      if(alias == null)
+      {
+        alias = target.OwnMeta.DefaultAlias;
+      }
       var context = this.CreateContext(target.OwnMeta.Name, alias, JoinType.From);
       context.Table = target;
       target.Context = context;

--- a/Sdx/Db/TableMeta.cs
+++ b/Sdx/Db/TableMeta.cs
@@ -127,36 +127,5 @@ namespace Sdx.Db
       this.CheckColumn(columnName);
       return this.columnsCache[columnName];
     }
-
-    public Sql.Condition CreateJoinCondition(string tableName, string alias = null)
-    {
-      if(alias == null)
-      {
-        alias = tableName;
-      }
-
-      var cond = new Sql.Condition();
-
-      Table.Relation relation;
-      if (this.Relations.ContainsKey(alias))
-      {
-        relation = this.Relations[alias];
-      }
-      else if (this.Relations.ContainsKey(tableName))
-      {
-        relation = this.Relations[tableName];
-      }
-      else
-      {
-        throw new KeyNotFoundException("Missing " + alias + " relation in " + this.TableType);
-      }
-
-      cond.Add(
-        new Sql.Column(relation.ForeignKey, this.Name),
-        new Sql.Column(relation.ReferenceKey, alias)
-      );
-
-      return cond;
-    }
   }
 }

--- a/Sdx/Db/TableMeta.cs
+++ b/Sdx/Db/TableMeta.cs
@@ -15,10 +15,11 @@ namespace Sdx.Db
       List<Table.Column> columns,
       Dictionary<string, Sdx.Db.Table.Relation> relations,
       Type recordType,
-      Type tableType
+      Type tableType,
+      String defaultAlias = null
     ){
       this.name = name;
-      InitializeTableMeta(columns, relations, recordType, tableType);
+      InitializeTableMeta(columns, relations, recordType, tableType, defaultAlias);
     }
 
     public TableMeta(
@@ -26,21 +27,24 @@ namespace Sdx.Db
       List<Table.Column> columns,
       Dictionary<string, Sdx.Db.Table.Relation> relations,
       Type recordType,
-      Type tableType
+      Type tableType,
+      String defaultAlias = null
     )
     {
       this.NameGetter = nameGetter;
-      InitializeTableMeta(columns, relations, recordType, tableType);
+      InitializeTableMeta(columns, relations, recordType, tableType, defaultAlias);
     }
 
     private void InitializeTableMeta(
       List<Table.Column> columns,
       Dictionary<string, Sdx.Db.Table.Relation> relations,
       Type recordType,
-      Type tableType)
-    {
+      Type tableType,
+      string defaultAlias
+    ){
       this.Columns = columns;
       this.Relations = relations;
+      this.DefaultAlias = defaultAlias;
 
       if (!typeof(Sdx.Db.Record).IsAssignableFrom(recordType))
       {
@@ -81,6 +85,7 @@ namespace Sdx.Db
     public Type TableType { get; private set; }
     public Type RecordType { get; private set; }
     public Func<string> NameGetter { get; private set; }
+    public String DefaultAlias { get; private set; }
 
     private Dictionary<string, Table.Column> columnsCache = new Dictionary<string, Table.Column>();
 

--- a/UnitTest/Sdx/Db/Record.cs
+++ b/UnitTest/Sdx/Db/Record.cs
@@ -565,7 +565,10 @@ namespace UnitTest
 
       select.Context("shop").InnerJoin(
         "menu",
-        Test.Orm.Table.Shop.Meta.CreateJoinCondition("menu")
+        db.Adapter.CreateCondition().Add(
+          new Sdx.Db.Sql.Column("id", "shop"),
+          new Sdx.Db.Sql.Column("shop_id", "menu")
+        )
       );
 
       using (var conn = db.Adapter.CreateConnection())

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2450,10 +2450,10 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
     {
       var db = testDb.Adapter;
       
-      #region JOINなし
+      #region JOINなし エイリアス指定
       {
         var select = db.CreateSelect();
-        select.AddFrom(new Test.Orm.Table.ShopWithSchema(), cShop =>
+        select.AddFrom(new Test.Orm.Table.ShopWithSchema(), "Shop", cShop =>
         {
           cShop.Where.Add("id", 1);
         });
@@ -2480,7 +2480,7 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
 
         Assert.Equal(
           testDb.Sql(
-            @"SELECT {0}dbo$shop{1}.{0}id{1} AS {0}id@dbo$shop{1}, {0}dbo$shop{1}.{0}name{1} AS {0}name@dbo$shop{1}, {0}dbo$shop{1}.{0}area_id{1} AS {0}area_id@dbo$shop{1}, {0}dbo$shop{1}.{0}main_image_id{1} AS {0}main_image_id@dbo$shop{1}, {0}dbo$shop{1}.{0}sub_image_id{1} AS {0}sub_image_id@dbo$shop{1}, {0}dbo$shop{1}.{0}login_id{1} AS {0}login_id@dbo$shop{1}, {0}dbo$shop{1}.{0}password{1} AS {0}password@dbo$shop{1}, {0}dbo$shop{1}.{0}created_at{1} AS {0}created_at@dbo$shop{1} FROM {0}dbo{1}.{0}shop{1} AS {0}dbo$shop{1} WHERE {0}dbo$shop{1}.{0}id{1} = @0"
+            @"SELECT {0}Shop{1}.{0}id{1} AS {0}id@Shop{1}, {0}Shop{1}.{0}name{1} AS {0}name@Shop{1}, {0}Shop{1}.{0}area_id{1} AS {0}area_id@Shop{1}, {0}Shop{1}.{0}main_image_id{1} AS {0}main_image_id@Shop{1}, {0}Shop{1}.{0}sub_image_id{1} AS {0}sub_image_id@Shop{1}, {0}Shop{1}.{0}login_id{1} AS {0}login_id@Shop{1}, {0}Shop{1}.{0}password{1} AS {0}password@Shop{1}, {0}Shop{1}.{0}created_at{1} AS {0}created_at@Shop{1} FROM {0}dbo{1}.{0}shop{1} AS {0}Shop{1} WHERE {0}Shop{1}.{0}id{1} = @0"
           ),
           sql
         );

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2435,5 +2435,101 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
         Sdx.Context.Current.DbProfiler.Logs[1].CommandText
       );
     }
+
+    [Fact]
+    public void TestTableWithSchema()
+    {
+      foreach (TestDb db in this.CreateTestDbList())
+      {
+        RunTableWithSchema(db);
+        ExecSql(db);
+      }
+    }
+
+    private void RunTableWithSchema(TestDb testDb)
+    {
+      var db = testDb.Adapter;
+      
+      #region JOINなし
+      {
+        var select = db.CreateSelect();
+        select.AddFrom(new Test.Orm.Table.ShopWithSchema(), cShop =>
+        {
+          cShop.Where.Add("id", 1);
+        });
+
+        string sql;
+
+        if (testDb.Adapter is Sdx.Db.Adapter.SqlServer)
+        {
+          Sdx.Context.Current.DbProfiler = new Sdx.Db.Sql.Profiler();
+          using (var conn = db.CreateConnection())
+          {
+            conn.Open();
+            var shops = conn.FetchRecordSet(select);
+            Assert.Equal(1, shops.Count);
+            Assert.Equal(1, shops[0].GetInt32("id"));
+          }
+
+          sql = Sdx.Context.Current.DbProfiler.Logs[1].CommandText;
+        }
+        else
+        {
+          sql = select.Build().CommandText;
+        }
+
+        Assert.Equal(
+          testDb.Sql(
+            @"SELECT {0}dbo$shop{1}.{0}id{1} AS {0}id@dbo$shop{1}, {0}dbo$shop{1}.{0}name{1} AS {0}name@dbo$shop{1}, {0}dbo$shop{1}.{0}area_id{1} AS {0}area_id@dbo$shop{1}, {0}dbo$shop{1}.{0}main_image_id{1} AS {0}main_image_id@dbo$shop{1}, {0}dbo$shop{1}.{0}sub_image_id{1} AS {0}sub_image_id@dbo$shop{1}, {0}dbo$shop{1}.{0}login_id{1} AS {0}login_id@dbo$shop{1}, {0}dbo$shop{1}.{0}password{1} AS {0}password@dbo$shop{1}, {0}dbo$shop{1}.{0}created_at{1} AS {0}created_at@dbo$shop{1} FROM {0}dbo{1}.{0}shop{1} AS {0}dbo$shop{1} WHERE {0}dbo$shop{1}.{0}id{1} = @0"
+          ),
+          sql
+        );
+      }
+      #endregion
+
+      //#region JOINあり
+      //{
+      //  var select = db.CreateSelect();
+      //  select.AddFrom(new Test.Orm.Table.ShopWithSchema(), cShop =>
+      //  {
+      //    cShop.Where.Add("id", 1);
+      //    cShop.InnerJoin(new Test.Orm.Table.MenuWithSchema(), "Menu", cMenu => 
+      //    { 
+            
+      //    });
+      //  });
+
+      //  Sdx.Context.Current.Debug.Log(select.Build().CommandText);
+
+      //  string sql;
+
+      //  if (testDb.Adapter is Sdx.Db.Adapter.SqlServer)
+      //  {
+      //    Sdx.Context.Current.DbProfiler = new Sdx.Db.Sql.Profiler();
+      //    using (var conn = db.CreateConnection())
+      //    {
+      //      conn.Open();
+      //      var shops = conn.FetchRecordSet(select);
+      //      Assert.Equal(1, shops.Count);
+      //      Assert.Equal(1, shops[0].GetInt32("id"));
+      //    }
+
+      //    sql = Sdx.Context.Current.DbProfiler.Logs[1].CommandText;
+      //  }
+      //  else
+      //  {
+      //    sql = select.Build().CommandText;
+      //  }
+
+      //  //Assert.Equal(
+      //  //  testDb.Sql(
+      //  //    @"SELECT {0}dbo$shop{1}.{0}id{1} AS {0}id@dbo$shop{1}, {0}dbo$shop{1}.{0}name{1} AS {0}name@dbo$shop{1}, {0}dbo$shop{1}.{0}area_id{1} AS {0}area_id@dbo$shop{1}, {0}dbo$shop{1}.{0}main_image_id{1} AS {0}main_image_id@dbo$shop{1}, {0}dbo$shop{1}.{0}sub_image_id{1} AS {0}sub_image_id@dbo$shop{1}, {0}dbo$shop{1}.{0}login_id{1} AS {0}login_id@dbo$shop{1}, {0}dbo$shop{1}.{0}password{1} AS {0}password@dbo$shop{1}, {0}dbo$shop{1}.{0}created_at{1} AS {0}created_at@dbo$shop{1} FROM {0}dbo{1}.{0}shop{1} AS {0}dbo$shop{1} WHERE {0}dbo$shop{1}.{0}id{1} = @0"
+      //  //  ),
+      //  //  sql
+      //  //);
+      //}
+      //#endregion
+
+    }
   }
 }

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2592,7 +2592,6 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
         );
       }
       #endregion
-
     }
   }
 }

--- a/UnitTest/Test/Orm/MenuWithSchema.cs
+++ b/UnitTest/Test/Orm/MenuWithSchema.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.Orm
+{
+  public class MenuWithSchema : Menu
+  {
+    public static new Sdx.Db.TableMeta Meta
+    {
+      get
+      {
+        return Test.Orm.Table.MenuWithSchema.Meta;
+      }
+    }
+  }
+}

--- a/UnitTest/Test/Orm/ShopWithSchema.cs
+++ b/UnitTest/Test/Orm/ShopWithSchema.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.Orm
+{
+  public class ShopWithSchema: Shop
+  {
+    public static new Sdx.Db.TableMeta Meta
+    {
+      get
+      {
+        return Test.Orm.Table.ShopWithSchema.Meta;
+      }
+    }
+  }
+}

--- a/UnitTest/Test/Orm/Table/Menu.cs
+++ b/UnitTest/Test/Orm/Table/Menu.cs
@@ -3,21 +3,23 @@ using System.Collections.Generic;
 
 namespace Test.Orm.Table
 {
-  class Menu : Test.Db.Table
+  public class Menu : Test.Db.Table
   {
     public static Sdx.Db.TableMeta Meta { get; private set; }
 
-    static Menu()
+    protected static List<Column> CreateColumns()
     {
-      Meta = new Sdx.Db.TableMeta(
-        "menu",
-        new List<Column>()
+      return new List<Column>()
         {
           new Column("id", isAutoIncrement: true, isPkey: true),
           new Column("name"),
           new Column("shop_id"),
-        },
-        new Dictionary<string, Relation>()
+        };
+    }
+
+    protected static Dictionary<string, Relation> CreateRelations()
+    {
+      return new Dictionary<string, Relation>()
         {
           {
             "shop",
@@ -27,7 +29,15 @@ namespace Test.Orm.Table
               "id"
             )
           }
-        },
+        };
+    }
+
+    static Menu()
+    {
+      Meta = new Sdx.Db.TableMeta(
+        "menu",
+        CreateColumns(),
+        CreateRelations(),
         typeof(Test.Orm.Menu),
         typeof(Test.Orm.Table.Menu)
       );

--- a/UnitTest/Test/Orm/Table/MenuWithSchema.cs
+++ b/UnitTest/Test/Orm/Table/MenuWithSchema.cs
@@ -19,7 +19,8 @@ namespace Test.Orm.Table
         CreateColumns(),
         Relations,
         typeof(Test.Orm.MenuWithSchema),
-        typeof(Test.Orm.Table.MenuWithSchema)
+        typeof(Test.Orm.Table.MenuWithSchema),
+        "menu"
       );
     }
   }

--- a/UnitTest/Test/Orm/Table/MenuWithSchema.cs
+++ b/UnitTest/Test/Orm/Table/MenuWithSchema.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.Orm.Table
+{
+  public class MenuWithSchema : Menu
+  {
+    public static new Sdx.Db.TableMeta Meta { get; private set; }
+
+    static MenuWithSchema()
+    {
+      var Relations = CreateRelations();
+
+      Meta = new Sdx.Db.TableMeta(
+        "dbo.shop",
+        CreateColumns(),
+        Relations,
+        typeof(Test.Orm.MenuWithSchema),
+        typeof(Test.Orm.Table.MenuWithSchema)
+      );
+    }
+  }
+}

--- a/UnitTest/Test/Orm/Table/MenuWithSchema.cs
+++ b/UnitTest/Test/Orm/Table/MenuWithSchema.cs
@@ -15,7 +15,7 @@ namespace Test.Orm.Table
       var Relations = CreateRelations();
 
       Meta = new Sdx.Db.TableMeta(
-        "dbo.shop",
+        "dbo.menu",
         CreateColumns(),
         Relations,
         typeof(Test.Orm.MenuWithSchema),

--- a/UnitTest/Test/Orm/Table/Shop.cs
+++ b/UnitTest/Test/Orm/Table/Shop.cs
@@ -7,11 +7,9 @@ namespace Test.Orm.Table
   {
     public static Sdx.Db.TableMeta Meta { get; private set; }
 
-    static Shop()
+    protected static List<Column> CreateColumns()
     {
-      Meta =  new Sdx.Db.TableMeta(
-        "shop",
-        new List<Column>()
+      return new List<Column>()
         {
           new Column("id", isAutoIncrement: true, isPkey: true),
           new Column("name"),
@@ -21,8 +19,12 @@ namespace Test.Orm.Table
           new Column("login_id", isNotNull: false),
           new Column("password", isNotNull: false),
           new Column("created_at", type: ColumnType.DateTime),
-        },
-        new Dictionary<string, Relation>()
+        };
+    }
+
+    protected static Dictionary<string, Relation> CreateRelations()
+    {
+      return new Dictionary<string, Relation>()
         {
           {
             "area",
@@ -64,7 +66,17 @@ namespace Test.Orm.Table
               "shop_id"
             )
           }
-        },
+        };
+    }
+
+
+
+    static Shop()
+    {
+      Meta =  new Sdx.Db.TableMeta(
+        "shop",
+        CreateColumns(),
+        CreateRelations(),
         typeof(Test.Orm.Shop),
         typeof(Test.Orm.Table.Shop)
       );

--- a/UnitTest/Test/Orm/Table/ShopWithSchema.cs
+++ b/UnitTest/Test/Orm/Table/ShopWithSchema.cs
@@ -14,7 +14,7 @@ namespace Test.Orm.Table
     {
       var Relations = CreateRelations();
 
-      Relations["Menu"] = new Relation(
+      Relations["menu"] = new Relation(
         typeof(Test.Orm.Table.MenuWithSchema),
         "id",
         "shop_id"

--- a/UnitTest/Test/Orm/Table/ShopWithSchema.cs
+++ b/UnitTest/Test/Orm/Table/ShopWithSchema.cs
@@ -25,7 +25,8 @@ namespace Test.Orm.Table
         CreateColumns(),
         Relations,
         typeof(Test.Orm.ShopWithSchema),
-        typeof(Test.Orm.Table.ShopWithSchema)
+        typeof(Test.Orm.Table.ShopWithSchema),
+        "shop"
       );
     }
   }

--- a/UnitTest/Test/Orm/Table/ShopWithSchema.cs
+++ b/UnitTest/Test/Orm/Table/ShopWithSchema.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.Orm.Table
+{
+  public class ShopWithSchema : Shop
+  {
+    public static new Sdx.Db.TableMeta Meta { get; private set; }
+
+    static ShopWithSchema()
+    {
+      var Relations = CreateRelations();
+
+      Relations["Menu"] = new Relation(
+        typeof(Test.Orm.Table.MenuWithSchema),
+        "id",
+        "shop_id"
+      );
+
+      Meta = new Sdx.Db.TableMeta(
+        "dbo.shop",
+        CreateColumns(),
+        Relations,
+        typeof(Test.Orm.ShopWithSchema),
+        typeof(Test.Orm.Table.ShopWithSchema)
+      );
+    }
+  }
+}

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -109,10 +109,14 @@
     <Compile Include="Test\Data\LargeArea.cs" />
     <Compile Include="Test\Db\Adapter.cs" />
     <Compile Include="Test\Db\Table.cs" />
+    <Compile Include="Test\Orm\MenuWithSchema.cs" />
     <Compile Include="Test\Orm\ShopImage.cs" />
     <Compile Include="Test\Orm\ShopImageType.cs" />
+    <Compile Include="Test\Orm\ShopWithSchema.cs" />
+    <Compile Include="Test\Orm\Table\MenuWithSchema.cs" />
     <Compile Include="Test\Orm\Table\ShopImage.cs" />
     <Compile Include="Test\Orm\Table\ShopImageType.cs" />
+    <Compile Include="Test\Orm\Table\ShopWithSchema.cs" />
     <Compile Include="Test\Route\LangRouteHandler.cs" />
     <Compile Include="Test\Scaffold\Area.cs" />
     <Compile Include="Test\Scaffold\LargeArea.cs" />


### PR DESCRIPTION
## 概要

* テーブルの関連付けをチェックしている``GetRelationName``部分で、RecordのTypeをシンプルにチェックして、関連付けがあるかどうかを確認している部分があり、Recordを継承しているパターンの場合に、上手く関連付けを認識出来ない場合があったので修正。
（現行のUnitTestは通っています）


* TableMetaの生成時の第一引数に、リンクサーバー関連で``LinkServerName.dbo.TableName``というような状態の文字列を渡して生成すると、このテーブルを使用してデータを取得する際、Aliasが設定されていないと、カラムのASに``AS [id@LinkServerName].[dbo].[TableName]``というような文字列が入ってしまう為「.」が不正な文字としてエラーになってしまう件を修正。
（現在修正作業中）
