### PR TITLE
UseConnectionのOpen判定を修正

### DIFF
--- a/Sdx/Db/Adapter/Base.cs
+++ b/Sdx/Db/Adapter/Base.cs
@@ -84,7 +84,7 @@ namespace Sdx.Db.Adapter
         throw new InvalidOperationException("Not match connection string " + conn.ConnectionString + " and " + ConnectionString);
       }
 
-      if (conn.State != ConnectionState.Open)
+      if (conn.State == ConnectionState.Closed)
       {
         conn.Open();
       }


### PR DESCRIPTION
## 概要

UseConnection内で
```C#
if (conn.State == ConnectionState.Closed) 
{
    conn.Open();
}
```
この判定をしている部分がありますが、

ConnectionStateには、
```C#
    // 概要:
    //     接続が閉じています。
    Closed = 0,
    //
    // 概要:
    //     接続が開いています。
    Open = 1,
    //
    // 概要:
    //     接続オブジェクトがデータ ソースに接続しています。
    Connecting = 2,
    //
    // 概要:
    //     接続オブジェクトがコマンドを実行しています。 この値は製品の将来のバージョンで使用するために予約されています。
    Executing = 4,
    //
    // 概要:
    //     接続オブジェクトがデータを検索しています。 この値は製品の将来のバージョンで使用するために予約されています。
    Fetching = 8,
    //
    // 概要:
    //     データ ソースへの接続が断絶しています。 この状態は接続が開かれているときだけ発生します。 この状態の接続は、いったん閉じてから再び開くことができる場合があります。
    //     この値は製品の将来のバージョンで使用するために予約されています。
    Broken = 16,
```

この様な状態がある様で、

* Connecting
* Executing
* Fetching
* Broken

この4つのStateについては、Openされている状態で起こるStateの為``Openである``という状態だけを見て、Openかどうかを判定するのが、微妙なようです。

（ただし、現状、殆どのStateが予約の為準備されているだけで、実際になる可能性があるのは``Connecting``のみの様）

今後の事も鑑みて、Closedじゃない時だけ、Open()を呼ぶ。
というようにしておいた方が良さそうなので、今の内に変更しておきます。