### PR TITLE
Sdx.Db.Sql.Context 取得用メソッドの追加

### DIFF
--- a/Sdx/Db/Sql/Context.cs
+++ b/Sdx/Db/Sql/Context.cs
@@ -578,5 +578,17 @@ namespace Sdx.Db.Sql
     {
       return (T)Table;
     }
+
+    /// <summary>
+    /// JOINされた<see cref="Context"/>の中から指定のテーブルクラスに該当するものを全て返します
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public IEnumerable<Context> JoinedContexts<T>() where T : Sdx.Db.Table
+    {
+      return this.Select.Contexts
+        .Where(context => context.ParentContext == this)
+        .Where(context => context.Table is T);
+    }
   }
 }

--- a/Sdx/Db/Sql/Select.cs
+++ b/Sdx/Db/Sql/Select.cs
@@ -790,5 +790,16 @@ namespace Sdx.Db.Sql
     {
       return new ContextActions(this);
     }
+
+    /// <summary>
+    /// AddFrom された Context を全て返します
+    /// </summary>
+    public IEnumerable<Context> Froms
+    {
+      get
+      {
+        return Contexts.Where(context => context.JoinType == JoinType.From);
+      }
+    }
   }
 }

--- a/UnitTest/Sdx/Db/Sql/Context.cs
+++ b/UnitTest/Sdx/Db/Sql/Context.cs
@@ -2,6 +2,7 @@
 using UnitTest.DummyClasses;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Data.Common;
 
 #if ON_VISUAL_STUDIO
@@ -53,8 +54,8 @@ namespace UnitTest
       var cCategory = select.Context("shop_category");
       var cMenu = select.Context("menu");
 
-      Assert.Equal("shop2", cCategory.GetJoinedContexts<Test.Orm.Table.Shop>().First.Name);
-      Assert.Equal("shop3", cMenu.GetJoinedContexts<Test.Orm.Table.Shop>().First.Name);
+      Assert.Equal("shop2", cCategory.JoinedContexts<Test.Orm.Table.Shop>().First().Name);
+      Assert.Equal("shop3", cMenu.JoinedContexts<Test.Orm.Table.Shop>().First().Name);
 
     }
   }

--- a/UnitTest/Sdx/Db/Sql/Context.cs
+++ b/UnitTest/Sdx/Db/Sql/Context.cs
@@ -22,5 +22,40 @@ namespace UnitTest
     {
       BaseDbTest.InitilizeClass(context);
     }
+
+    [Fact]
+    public void TestGetJoinedContext()
+    {
+      foreach (TestDb db in this.CreateTestDbList())
+      {
+        RunGetJoinedContext(db);
+      }
+    }
+
+    private void RunGetJoinedContext(TestDb testDb)
+    {
+      var db = testDb.Adapter;
+      var select = db.CreateSelect();
+
+      select.AddFrom(new Test.Orm.Table.Shop(), "shop1", cShop1 =>
+      {
+        cShop1.InnerJoin(new Test.Orm.Table.ShopCategory(), cShopCategory =>
+        {
+          cShopCategory.InnerJoin(new Test.Orm.Table.Shop(), "shop2");
+        });
+
+        cShop1.InnerJoin(new Test.Orm.Table.Menu(), cShopMenu =>
+        {
+          cShopMenu.InnerJoin(new Test.Orm.Table.Shop(), "shop3");
+        });
+      });
+
+      var cCategory = select.Context("shop_category");
+      var cMenu = select.Context("menu");
+
+      Assert("shop2", cCategory.GetJoinedContext<Test.Orm.Table.Shop>().Name);
+      Assert("shop3", cMenu.GetJoinedContext<Test.Orm.Table.Shop>().Name);
+
+    }
   }
 }

--- a/UnitTest/Sdx/Db/Sql/Context.cs
+++ b/UnitTest/Sdx/Db/Sql/Context.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+using UnitTest.DummyClasses;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+#if ON_VISUAL_STUDIO
+using FactAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
+using TestClassAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+using ClassInitializeAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute;
+using ClassCleanupAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute;
+using TestContext = Microsoft.VisualStudio.TestTools.UnitTesting.TestContext;
+#endif
+
+namespace UnitTest
+{
+  [TestClass]
+  public class Db_Sql_Context : BaseDbTest
+  {
+    [ClassInitialize]
+    public new static void InitilizeClass(TestContext context)
+    {
+      BaseDbTest.InitilizeClass(context);
+    }
+  }
+}

--- a/UnitTest/Sdx/Db/Sql/Context.cs
+++ b/UnitTest/Sdx/Db/Sql/Context.cs
@@ -53,8 +53,8 @@ namespace UnitTest
       var cCategory = select.Context("shop_category");
       var cMenu = select.Context("menu");
 
-      Assert("shop2", cCategory.GetJoinedContext<Test.Orm.Table.Shop>().Name);
-      Assert("shop3", cMenu.GetJoinedContext<Test.Orm.Table.Shop>().Name);
+      Assert.Equal("shop2", cCategory.GetJoinedContexts<Test.Orm.Table.Shop>().First.Name);
+      Assert.Equal("shop3", cMenu.GetJoinedContexts<Test.Orm.Table.Shop>().First.Name);
 
     }
   }

--- a/UnitTest/Sdx/Db/Sql/Context.cs
+++ b/UnitTest/Sdx/Db/Sql/Context.cs
@@ -25,15 +25,15 @@ namespace UnitTest
     }
 
     [Fact]
-    public void TestGetJoinedContext()
+    public void TestGetJoinedContexts()
     {
       foreach (TestDb db in this.CreateTestDbList())
       {
-        RunGetJoinedContext(db);
+        RunGetJoinedContexts(db);
       }
     }
 
-    private void RunGetJoinedContext(TestDb testDb)
+    private void RunGetJoinedContexts(TestDb testDb)
     {
       var db = testDb.Adapter;
       var select = db.CreateSelect();

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2618,7 +2618,8 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
         });
       });
 
-      Assert.Equal("shopFrom", select.GetFroms().Name);
+      var froms = select.Froms.Where(from => from.Table is Test.Orm.Table.Shop);
+      Assert.Equal("shopFrom", froms.First().Name);
     }
   }
 }

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2593,5 +2593,32 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
       }
       #endregion
     }
+
+    [Fact]
+    public void TestGetFromContext()
+    {
+      foreach (TestDb db in this.CreateTestDbList())
+      {
+        RunGetFromContext(db);
+        ExecSql(db);
+      }
+    }
+
+    private void RunGetFromContext(TestDb testDb)
+    {
+      var db = testDb.Adapter;
+      var select = db.CreateSelect();
+
+      //FROMとJOINどちらのshopかわかるようにエイリアスを付けておく
+      select.AddFrom(new Test.Orm.Table.Shop(), "shopFrom", cShoppp =>
+      {
+        cShoppp.InnerJoin(new Test.Orm.Table.ShopCategory(), cShopCategory =>
+        {
+          cShopCategory.InnerJoin(new Test.Orm.Table.Shop(), "shopJoin");
+        });
+      });
+
+      Assert.Equal("shopFrom", select.GetFroms().Name);
+    }
   }
 }

--- a/UnitTest/Sdx/Db/Sql/Select.cs
+++ b/UnitTest/Sdx/Db/Sql/Select.cs
@@ -2595,16 +2595,16 @@ SELECT `shop`.`id` AS `id@shop` FROM `shop`
     }
 
     [Fact]
-    public void TestGetFromContext()
+    public void TestGetFromContexts()
     {
       foreach (TestDb db in this.CreateTestDbList())
       {
-        RunGetFromContext(db);
+        RunGetFromContexts(db);
         ExecSql(db);
       }
     }
 
-    private void RunGetFromContext(TestDb testDb)
+    private void RunGetFromContexts(TestDb testDb)
     {
       var db = testDb.Adapter;
       var select = db.CreateSelect();

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Sdx\Db\Adapter.cs" />
     <Compile Include="Sdx\Db\Connection.cs" />
     <Compile Include="Sdx\Config.cs" />
+    <Compile Include="Sdx\Db\Sql\Context.cs" />
     <Compile Include="Sdx\Db\Sql\Delete.cs" />
     <Compile Include="Sdx\Db\Sql\Update.cs" />
     <Compile Include="Sdx\Db\Sql\Select.cs" />


### PR DESCRIPTION
## 概要
[`Sdx.Db.Sql.Select.Context("contextName")`](https://github.com/SunriseDigital/cs-sdx/blob/dfc8c24784bcabb030be941e7c727194dbcfce55/Sdx/Db/Sql/Select.cs#L430-L443) でコンテキストの取得は可能だが、
`Context()`の引数はエイリアスでの指定になるため、もし同じテーブルが別々に複数JOINされていて、取得したいコンテキストのエイリアスは違う名前を付けられていた場合、意図しないコンテキストが取得される恐れがある。

そのため、欲しいコンテキストを確実に取得できるように `Context()` とは別に以下のようなメソッドを追加する。(エイリアスで取得したい場合もあるので `Context()` がダメというわけではない)
```C#
//対象の context に JOIN されているテーブルのコンテキストを全て取得する。エイリアスではなくテーブルクラスで指定する。
targetContext.GetJoinedContexts<T>()
```

また、同様の理由で、FROMに指定されているテーブルのコンテキストを取得したい、という場合に同じテーブルがFROM以外にもJOINされている場合、エイリアス次第ではFROMじゃないほうが取得されるケースもあるため、確実にFROMから取得できるようにするためのメソッドも追加する
```C#
select.GetFroms()//select.GetFromContext() とかのほうがわかりやすい？まあそれはおいおい。
```