### PR TITLE
Travis上でのみテストがコケるのを修正する

### DIFF
--- a/UnitTest/Test/Db/Adapter.cs
+++ b/UnitTest/Test/Db/Adapter.cs
@@ -10,7 +10,7 @@ namespace Test.Db
   {
     public static String MySqlConnectionString
     {
-      get { return "Server=localhost;Database=sdxtest;Uid=sdxuser;Pwd=sdx5963;"; }
+      get { return "Server=localhost;Database=sdxtest;Uid=sdxuser;Pwd=sdx5963;CharSet=utf8;"; }
     }
 
     public static String SqlServerConnectionString


### PR DESCRIPTION
## 概要
Travisで以下のエラーが大量に出力されていた。
```
MySql.Data.MySqlClient.MySqlException : Subquery returns more than 1 row
```

Travis
https://travis-ci.org/SunriseDigital/cs-sdx/builds/289339444?utm_source=github_status&utm_medium=notification

上記は別のブランチで気が付いたが、調べてみると master ブランチの状態でも起きていた。

## 原因
ユニットテスト開始時にこのSQLが実行される。ところがこれが日本語が文字化けした状態(`???`みたいな)で Insert が実行されたと思われる。
https://github.com/SunriseDigital/cs-sdx/blob/master/UnitTest/insert.sql

DBに文字化けして格納されたのではなく、 Insert.sql が既に文字化けした状態で実行されていた可能性が高い。アルファベットは問題ないが日本語が化ける

例えばこんなかんじ。

- Insert.sql に書いてあるSQL => `INSERT INTO large_area (name, code) VALUES ('東京', 'tokyo');` 
  - 実行されたSQL=> `INSERT INTO large_area (name, code) VALUES ('??', 'tokyo');`
- Insert.sql に書いてあるSQL => `INSERT INTO area (name, code, large_area_id) VALUES ('新中野', 'sinnakano', (SELECT id FROM large_area WHERE code = 'tokyo'));`
  - 実行されたSQL=>  `INSERT INTO area (name, code, large_area_id) VALUES ('???', 'sinnakano', (SELECT id FROM large_area WHERE code = 'tokyo'));`

このとき、DBに保存されたデータは全部 `???` というエリア名で保存されている。

この状態でさらに以下を実行しようとする。
```SQL
INSERT INTO shop (name, created_at, area_id) VALUES ('天祥', '2015-01-01 12:30:00', (SELECT id FROM area WHERE name = '新中野'));
```

しかし実際は以下が実行される
```SQL
INSERT INTO shop (name, created_at, area_id) VALUES ('??', '2015-01-01 12:30:00', (SELECT id FROM area WHERE name = '???'));
```

問題がVALUES内のサブクエリ。
`WHERE name = '新中野'` であれば通常は1件しか返ってこないはずだが、これが `WHERE name = '???'` で実行されると `西麻布`や`矢場町` も `???` でDBに保存されているためこれらもヒットしてしまい、結果が複数行返ってくる。だから`Subquery returns more than 1 row` になっていた、と考えると全て辻褄が合う。Travis側の仕様が変わったのだろうか(そこまでは不明。)
判明してみれば単純なことではあったが、Travisでしかエラーが再現しないためとにかくDumpの類が一切できなかったので調査は相当難航した。。。

## 調査用PR
こちらでいろいろ検証した結果判明。
https://github.com/SunriseDigital/cs-sdx/pull/141

