### PR TITLE
Sdx.SplittableText クラス作成

### DIFF
--- a/Sdx/Sdx.csproj
+++ b/Sdx/Sdx.csproj
@@ -60,6 +60,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SplittableText.cs" />
     <Compile Include="Cli\Options\Db.cs" />
     <Compile Include="Cli\Options\IDbConnection.cs" />
     <Compile Include="Collection\Holder.cs" />

--- a/Sdx/SplittableText.cs
+++ b/Sdx/SplittableText.cs
@@ -13,7 +13,7 @@ namespace Sdx
     /// </summary>
     /// <param name="targetText">対象文字列</param>
     /// <param name="boundary">区切り文字</param>
-    public SplittableText(string targetText, string boundary = "@Sdx.SplittableString.Boundary@")
+    public SplittableText(string targetText, string boundary = "@Sdx.SplittableText.Boundary@")
     {
       RawText = targetText;
       Boundary = boundary;

--- a/Sdx/SplittableText.cs
+++ b/Sdx/SplittableText.cs
@@ -17,11 +17,11 @@ namespace Sdx
     {
       RawText = targetText;
       Boundary = boundary;
-      Parts = RawText
+      parts = RawText
         .Split(new string[] { Boundary }, StringSplitOptions.None)
         .Select(x => x.Trim()).ToArray<string>()
       ;
-      HasBoundaryString = (Parts.Any() && Parts.Skip(1).Any());
+      HasBoundaryString = (parts.Any() && parts.Skip(1).Any());
     }
 
     /// <summary>
@@ -45,10 +45,22 @@ namespace Sdx
     /// <summary>
     /// RawText を Boundary で区切って配列にしたもの
     /// </summary>
-    public string[] Parts
+    private string[] parts;
+
+    public int PartCount
     {
-      get;
-      private set;
+      get
+      {
+        return parts.Length;
+      }
+    }
+
+    public bool HasMultipleParts
+    {
+      get
+      {
+        return PartCount > 1;
+      }
     }
 
     /// <summary>
@@ -64,7 +76,7 @@ namespace Sdx
     {
       get
       {
-        return Parts.FirstOrDefault();
+        return parts.FirstOrDefault();
       }
     }
 
@@ -72,7 +84,7 @@ namespace Sdx
     {
       get
       {
-        return Parts.LastOrDefault();
+        return parts.LastOrDefault();
       }
     }
 
@@ -84,12 +96,12 @@ namespace Sdx
     /// <returns></returns>
     public string PartAt(int nth)
     {
-      if (nth < 1 || nth > Parts.Length)
+      if (nth < 1 || nth > parts.Length)
       {
         return null;
       }
 
-      return Parts[nth - 1];
+      return parts[nth - 1];
     }
   }
 }

--- a/Sdx/SplittableText.cs
+++ b/Sdx/SplittableText.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sdx
+{
+  public class SplittableText
+  {
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="targetText">対象文字列</param>
+    /// <param name="boundary">区切り文字</param>
+    public SplittableText(string targetText, string boundary = "@Sdx.SplittableString.Boundary@")
+    {
+      RawText = targetText;
+      Boundary = boundary;
+      Parts = RawText.Split(new string[] { Boundary }, StringSplitOptions.None);
+      HasBoundaryString = (Parts.Any() && Parts.Skip(1).Any());
+    }
+
+    /// <summary>
+    /// 対象文字列を区切って配列にする際に使う区切り文字列
+    /// </summary>
+    public string Boundary
+    {
+      get;
+      private set;
+    }
+
+    /// <summary>
+    /// 元の文字列
+    /// </summary>
+    public string RawText
+    {
+      get;
+      private set;
+    }
+
+    /// <summary>
+    /// RawText を Boundary で区切って配列にしたもの
+    /// </summary>
+    public string[] Parts
+    {
+      get;
+      private set;
+    }
+
+    /// <summary>
+    /// 元の文字列に Boundary と同じ文字列があるかのフラグ
+    /// </summary>
+    public bool HasBoundaryString
+    {
+      get;
+      private set;
+    }
+
+    public string First
+    {
+      get
+      {
+        return Parts.FirstOrDefault();
+      }
+    }
+
+    public string Last
+    {
+      get
+      {
+        return Parts.LastOrDefault();
+      }
+    }
+
+    /// <summary>
+    /// Partsから引数で指定されたn番目の要素を返す(先頭なら 1 が引数になる)
+    /// 存在しない要素の場合は null を返す
+    /// </summary>
+    /// <param name="nth"></param>
+    /// <returns></returns>
+    public string PartAt(int nth)
+    {
+      if (nth < 1 || nth > Parts.Length)
+      {
+        return null;
+      }
+
+      return Parts[nth - 1];
+    }
+  }
+}

--- a/Sdx/SplittableText.cs
+++ b/Sdx/SplittableText.cs
@@ -17,7 +17,10 @@ namespace Sdx
     {
       RawText = targetText;
       Boundary = boundary;
-      Parts = RawText.Split(new string[] { Boundary }, StringSplitOptions.None);
+      Parts = RawText
+        .Split(new string[] { Boundary }, StringSplitOptions.None)
+        .Select(x => x.Trim()).ToArray<string>()
+      ;
       HasBoundaryString = (Parts.Any() && Parts.Skip(1).Any());
     }
 

--- a/Sdx/SplittableText.cs
+++ b/Sdx/SplittableText.cs
@@ -21,7 +21,6 @@ namespace Sdx
         .Split(new string[] { Boundary }, StringSplitOptions.None)
         .Select(x => x.Trim()).ToArray<string>()
       ;
-      HasBoundaryString = (parts.Any() && parts.Skip(1).Any());
     }
 
     /// <summary>
@@ -61,15 +60,6 @@ namespace Sdx
       {
         return PartCount > 1;
       }
-    }
-
-    /// <summary>
-    /// 元の文字列に Boundary と同じ文字列があるかのフラグ
-    /// </summary>
-    public bool HasBoundaryString
-    {
-      get;
-      private set;
     }
 
     public string First

--- a/UnitTest/Sdx/SplittableText.cs
+++ b/UnitTest/Sdx/SplittableText.cs
@@ -1,0 +1,57 @@
+﻿using Xunit;
+
+#if ON_VISUAL_STUDIO
+using FactAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
+using TestClassAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+#endif
+
+namespace UnitTest
+{
+  [TestClass]
+  public class SplittableText : BaseTest
+  {
+    [Fact]
+    public void TestBasic()
+    {
+      var target = "aaaaaaaaaa@Sdx.SplittableText.Boundary@bbbbbbbbbb@Sdx.SplittableText.Boundary@cccccccccc";
+      var splittable = new Sdx.SplittableText(target);
+
+      Assert.Equal(3, splittable.Parts.Length);
+      Assert.Equal("aaaaaaaaaa", splittable.First);
+      Assert.Equal("cccccccccc", splittable.Last);
+      Assert.Equal("bbbbbbbbbb", splittable.PartAt(2));
+      Assert.Equal(true, splittable.HasBoundaryString);
+    }
+
+    [Fact]
+    public void TestFreeBoundarySetting()
+    {
+      var target = "aaaaaaaaaa---myBoundary---bbbbbbbbbb";
+      var splittable = new Sdx.SplittableText(target, "---myBoundary---");
+
+      Assert.Equal("aaaaaaaaaa", splittable.First);
+      Assert.Equal("bbbbbbbbbb", splittable.Last);
+    }
+
+    [Fact]
+    public void TestNonPresenceItem()
+    {
+      var target = "aaaaaaaaaa@Sdx.SplittableText.Boundary@bbbbbbbbbb";
+      var splittable = new Sdx.SplittableText(target);
+
+      Assert.Equal(null, splittable.PartAt(999));
+      Assert.Equal(null, splittable.PartAt(-1));
+    }
+
+    [Fact]
+    public void TestTrim()
+    {
+      var target = "    aaaaaaaaaa    @Sdx.SplittableText.Boundary@    bbbbbbbbbb     ";
+      var splittable = new Sdx.SplittableText(target);
+
+      Assert.Equal("aaaaaaaaaa", splittable.First);
+      Assert.Equal("bbbbbbbbbb", splittable.Last);
+    }
+  }
+}
+

--- a/UnitTest/Sdx/SplittableText.cs
+++ b/UnitTest/Sdx/SplittableText.cs
@@ -1,9 +1,19 @@
 ﻿using Xunit;
+using UnitTest.DummyClasses;
 
 #if ON_VISUAL_STUDIO
 using FactAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
 using TestClassAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+using ClassInitializeAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute;
+using ClassCleanupAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute;
+using TestContext = Microsoft.VisualStudio.TestTools.UnitTesting.TestContext;
 #endif
+
+using System;
+
+using System.IO;
+using System.Collections.Generic;
+using System.Text;
 
 namespace UnitTest
 {

--- a/UnitTest/Sdx/SplittableText.cs
+++ b/UnitTest/Sdx/SplittableText.cs
@@ -20,6 +20,7 @@ namespace UnitTest
       Assert.Equal("aaaaaaaaaa", splittable.First);
       Assert.Equal("cccccccccc", splittable.Last);
       Assert.Equal("bbbbbbbbbb", splittable.PartAt(2));
+      Assert.Equal(target, splittable.RawText);
       Assert.Equal(true, splittable.HasBoundaryString);
     }
 

--- a/UnitTest/Sdx/SplittableText.cs
+++ b/UnitTest/Sdx/SplittableText.cs
@@ -26,12 +26,12 @@ namespace UnitTest
       var target = "aaaaaaaaaa@Sdx.SplittableText.Boundary@bbbbbbbbbb@Sdx.SplittableText.Boundary@cccccccccc";
       var splittable = new Sdx.SplittableText(target);
 
-      Assert.Equal(3, splittable.Parts.Length);
+      Assert.Equal(3, splittable.PartCount);
       Assert.Equal("aaaaaaaaaa", splittable.First);
       Assert.Equal("cccccccccc", splittable.Last);
       Assert.Equal("bbbbbbbbbb", splittable.PartAt(2));
       Assert.Equal(target, splittable.RawText);
-      Assert.Equal(true, splittable.HasBoundaryString);
+      Assert.Equal(true, splittable.HasMultipleParts);
     }
 
     [Fact]

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -103,6 +103,7 @@
     <Compile Include="BaseTest.cs" />
     <Compile Include="Sdx\Pager.cs" />
     <Compile Include="Sdx\Scaffold\Manager.cs" />
+    <Compile Include="Sdx\SplittableText.cs" />
     <Compile Include="Sdx\Validation\ImageValidator.cs" />
     <Compile Include="Sdx\Web\DeviceTable.cs" />
     <Compile Include="Sdx\Web\DeviceUrl.cs" />


### PR DESCRIPTION
## 概要
文章を区切り文字で分割して扱う汎用的なクラスを作ることになりました。

## インターフェース
```C#
var splittable = new Sdx.SplittableText(SomeString);
splittable.FirstPart;
splittable.LastPart;
splittable.PartAt(1);
splittable.RawText;
splittable.Parts;
```